### PR TITLE
Scope blocks endpoint to authenticated user

### DIFF
--- a/app/policies/block_policy.rb
+++ b/app/policies/block_policy.rb
@@ -3,4 +3,10 @@ class BlockPolicy < ApplicationPolicy
     record.user == user
   end
   alias_method :destroy?, :create?
+
+  class Scope < Scope
+    def resolve
+      scope.where(user: user)
+    end
+  end
 end


### PR DESCRIPTION
So Blocks aren't queryable by everyone.