### PR TITLE
Add group feeds to #feed_visible?

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -69,6 +69,10 @@ class FeedsController < ApplicationController
     when 'user', 'user_aggr'
       user = User.find_by(id: params[:id])
       user && show?(user)
+    when 'group', 'group_aggr'
+      group = Group.find_by(id: params[:id])
+      return true if group && !group.closed?
+      group && current_user && group.member_for(current_user.resource_owner)
     when 'notifications', 'timeline'
       user = User.find_by(id: params[:id])
       user == current_user.resource_owner


### PR DESCRIPTION
PR'ing to be sure that :100:. Allow group feeds to be visible and check for membership on a closed group.

/cc @NuckChorris 