### PR TITLE
Add title to GroupTicket

### DIFF
--- a/app/models/group_ticket.rb
+++ b/app/models/group_ticket.rb
@@ -5,6 +5,7 @@
 #
 #  id          :integer          not null, primary key
 #  status      :integer          default(0), not null, indexed
+#  title       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  assignee_id :integer          indexed

--- a/app/resources/group_ticket_resource.rb
+++ b/app/resources/group_ticket_resource.rb
@@ -1,7 +1,7 @@
 class GroupTicketResource < BaseResource
   include GroupActionLogger
 
-  attributes :status, :created_at
+  attributes :title, :status, :created_at
 
   has_one :user
   has_one :group

--- a/db/migrate/20170302234018_add_title_to_group_tickets.rb
+++ b/db/migrate/20170302234018_add_title_to_group_tickets.rb
@@ -1,0 +1,5 @@
+class AddTitleToGroupTickets < ActiveRecord::Migration
+  def change
+    add_column :group_tickets, :title, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170302195631) do
+ActiveRecord::Schema.define(version: 20170302234018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -472,6 +472,7 @@ ActiveRecord::Schema.define(version: 20170302195631) do
     t.integer  "status",      default: 0, null: false
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
+    t.string   "title",                   null: false
   end
 
   add_index "group_tickets", ["assignee_id"], name: "index_group_tickets_on_assignee_id", using: :btree

--- a/spec/factories/group_tickets.rb
+++ b/spec/factories/group_tickets.rb
@@ -5,6 +5,7 @@
 #
 #  id          :integer          not null, primary key
 #  status      :integer          default(0), not null, indexed
+#  title       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  assignee_id :integer          indexed
@@ -28,6 +29,7 @@
 
 FactoryGirl.define do
   factory :group_ticket do
+    title { Faker::Lorem.sentence }
     association :group, strategy: :build
     association :user, strategy: :build
   end

--- a/spec/models/group_ticket_spec.rb
+++ b/spec/models/group_ticket_spec.rb
@@ -5,6 +5,7 @@
 #
 #  id          :integer          not null, primary key
 #  status      :integer          default(0), not null, indexed
+#  title       :string           not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #  assignee_id :integer          indexed


### PR DESCRIPTION
Adds a `title` column to the `GroupTicket` table.

This change is based on the design/spec, and is useful for short-form display purposes as messages can be large and are Markdown enabled.

:heart: /ping @NuckChorris 