### PR TITLE
Fix next link feed serializer

### DIFF
--- a/app/services/feed_serializer_service.rb
+++ b/app/services/feed_serializer_service.rb
@@ -113,7 +113,7 @@ class FeedSerializerService
     uri = URI.parse(base_url)
     query = URI.decode_www_form(uri.query || '').to_h.merge(params)
     uri.query = URI.encode_www_form(query.to_a)
-    uri.path = "/api#{uri.path}"
+    uri.path = "#{uri.path}"
     uri.to_s
   end
 

--- a/app/services/feed_serializer_service.rb
+++ b/app/services/feed_serializer_service.rb
@@ -113,7 +113,6 @@ class FeedSerializerService
     uri = URI.parse(base_url)
     query = URI.decode_www_form(uri.query || '').to_h.merge(params)
     uri.query = URI.encode_www_form(query.to_a)
-    uri.path = "#{uri.path}"
     uri.to_s
   end
 


### PR DESCRIPTION
At the moment the `next` url in the links response has a double `/api` in its path for the feeds requests:

`"links": { "next":"https://kitsu.io/api/api/edge/feeds/..." }`