### PR TITLE
Show abbreviated_titles field in rails admin

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -45,8 +45,8 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   # Anime
   config.model 'Anime' do
     field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    fields :canonical_title, :synopsis, :slug, :subtype, :poster_image,
-      :cover_image, :age_rating, :age_rating_guide
+    fields :canonical_title, :abbreviated_titles, :synopsis, :slug, :subtype,
+      :poster_image, :cover_image, :age_rating, :age_rating_guide
     include_all_fields
     exclude_fields :library_entries, :inverse_media_relationships, :favorites,
       :producers, :average_rating, :cover_image_top_offset
@@ -60,8 +60,8 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   # Manga
   config.model 'Manga' do
     field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    fields :canonical_title, :synopsis, :slug, :subtype, :poster_image,
-      :cover_image, :age_rating, :age_rating_guide
+    fields :canonical_title, :abbreviated_titles, :synopsis, :slug, :subtype,
+      :poster_image, :cover_image, :age_rating, :age_rating_guide
     include_all_fields
     navigation_label 'Manga'
     weight(-15)
@@ -72,8 +72,8 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   # Drama
   config.model 'Drama' do
     field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    fields :canonical_title, :synopsis, :slug, :subtype, :poster_image,
-      :cover_image, :age_rating, :age_rating_guide
+    fields :canonical_title, :abbreviated_titles, :synopsis, :slug, :subtype,
+      :poster_image, :cover_image, :age_rating, :age_rating_guide
     include_all_fields
     navigation_label 'Drama'
     weight(0)


### PR DESCRIPTION
Shows the `abbreviated_titles` field so synonyms can be added through rails admin.