### PR TITLE
Hide STI better

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -271,7 +271,7 @@ class User < ApplicationRecord
     update_profile_completed.save!
   end
 
-  after_create do
+  after_commit on: :create do
     # Send Confirmation Email
     UserMailer.confirmation(self).deliver_later
     # Set up feeds

--- a/app/resources/concerns/sti_resource.rb
+++ b/app/resources/concerns/sti_resource.rb
@@ -10,6 +10,7 @@ module STIResource
   end
 
   included do
+    attribute :kind
     filter :kind, apply: ->(records, values, _options) {
       prefix = self.class._model_name
       kinds = values.map { |v| "#{prefix}::#{v.underscore.classify}" }

--- a/app/resources/concerns/sti_resource.rb
+++ b/app/resources/concerns/sti_resource.rb
@@ -1,0 +1,19 @@
+module STIResource
+  extend ActiveSupport::Concern
+
+  def kind
+    _model.type.demodulize.underscore.dasherize
+  end
+
+  def kind=(val)
+    _model.type = "#{self.class._model_name}::#{val.underscore.classify}"
+  end
+
+  included do
+    filter :kind, apply: ->(records, values, _options) {
+      prefix = self.class._model_name
+      kinds = values.map { |v| "#{prefix}::#{v.underscore.classify}" }
+      records.where(type: kinds)
+    }
+  end
+end

--- a/app/resources/linked_account_resource.rb
+++ b/app/resources/linked_account_resource.rb
@@ -1,8 +1,10 @@
 class LinkedAccountResource < BaseResource
+  include STIResource
+
   model_hint model: LinkedAccount::MyAnimeList
 
   attributes :external_user_id, :token, :share_to,
-    :share_from, :sync_to, :kind
+    :share_from, :sync_to
   # :kind is aliased to :type in LinkedAccount
 
   has_one :user

--- a/app/resources/list_import_resource.rb
+++ b/app/resources/list_import_resource.rb
@@ -1,10 +1,12 @@
 class ListImportResource < BaseResource
+  include STIResource
+
   model_hint model: ListImport::MyAnimeList
   model_hint model: ListImport::AnimePlanet
   model_hint model: ListImport::Anilist
 
   # Parameters
-  attributes :input_text, :strategy, :kind, :created_at
+  attributes :input_text, :strategy, :created_at
   attribute :input_file, format: :attachment
   # Status
   attributes :progress, :status, :total

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -4,4 +4,5 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.uncountable %w[anime manga media anime_staff manga_staff drama_staff]
   inflect.acronym 'XML'
   inflect.acronym 'SSO'
+  inflect.acronym 'STI'
 end


### PR DESCRIPTION
So, we've discussed this a few times, fixing the leakage of Ruby class names into the API.

This fixes that by replacing `kind: "LinkedAccount::MyAnimeList"` and `kind: "ListImport::Anilist"` with `kind: "my-anime-list"` and `kind: "anilist"`, which seems a way better way of hiding it.

THAT SAID!  It's likely a breaking change for any sane clients, so we need to discuss how to do this.  I can think of two possible things:

1. Use a different field name temporarily while we switch over
2. Fuck that shit and just flip the client at the same time

I'm pretty sure no third-party clients currently support either of our STI models (ListImport and LinkedAccount), so this should be up to you and me @vevix