### PR TITLE
Refactor feed filtering to use split feeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem 'nokogiri', '~> 1.7.1' # Parse MAL XML shit
 gem 'paranoia', '~> 2.0' # Faux deletion
 gem 'ruby-progressbar' # Fancy progress bars for Rake tasks
 gem 'sitemap_generator' # Generate Sitemaps
-gem 'stream-ruby', '~> 2.5.2'
+gem 'stream-ruby', '~> 2.5.4'
 gem 'stream_rails', github: 'GetStream/stream-rails', branch: 'feature/subreference-enrichment' # Feeds
 gem 'typhoeus' # Parallelize scraping tasks
 
@@ -99,11 +99,13 @@ group :test do
   gem 'simplecov' # Local coverage
   gem 'timecop' # stop [hammer-]time
   gem 'webmock' # Web faking
+  gem 'test_after_commit' # Rails 4 doesn't run commit callbacks on transactions
 
   # Libraries used to test our API itself
   gem 'oauth2'
 end
 
 group :production, :staging do
+  gem 'puma_worker_killer'
   gem 'rails_12factor' # Log to stdout, serve assets
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,10 +473,12 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    stream-ruby (2.5.2)
+    stream-ruby (2.5.4)
       faraday (~> 0.10.0)
       http_signatures (~> 0)
       jwt (= 1.5.2)
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.6)
@@ -574,8 +576,9 @@ DEPENDENCIES
   sinatra
   sitemap_generator
   spring
-  stream-ruby (~> 2.5.2)
+  stream-ruby (~> 2.5.4)
   stream_rails!
+  test_after_commit
   timecop
   twitter
   typhoeus

--- a/app/models/concerns/media.rb
+++ b/app/models/concerns/media.rb
@@ -64,15 +64,30 @@ module Media
     (end_date || Date.today) - start_date if start_date
   end
 
-  def feed
-    @feed ||= Feed.media(self.class.name, id)
+  def posts_feed
+    @posts_feed ||= Feed.media_posts(self.class.name, id)
+  end
+
+  def media_feed
+    @media_feed ||= Feed.media_media(self.class.name, id)
   end
 
   def aggregated_feed
     @aggregated_feed ||= Feed.media_aggr(self.class.name, id)
   end
 
+  def posts_aggregated_feed
+    @posts_aggregated_feed ||= Feed.media_posts_aggr(self.class.name, id)
+  end
+
+  def media_aggregated_feed
+    @media_aggregated_feed ||= Feed.media_media_aggr(self.class.name, id)
+  end
+
   def follow_self
-    aggregated_feed.follow(feed)
+    aggregated_feed.follow(posts_feed)
+    aggregated_feed.follow(media_feed)
+    posts_aggregated_feed.follow(posts_feed)
+    media_aggregated_feed.follow(media_feed)
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -1,16 +1,26 @@
 class Feed
   FEED_GROUPS = {
-    user: :flat,
+    user_posts: :flat,
+    user_media: :flat,
     user_aggr: :aggregated,
-    media: :flat,
+    user_posts_aggr: :aggregated,
+    user_media_aggr: :aggregated,
+    media_posts: :flat,
+    media_media: :flat,
     media_aggr: :aggregated,
+    media_posts_aggr: :aggregated,
+    media_media_aggr: :aggregated,
     group: :flat,
     group_aggr: :aggregated,
     post: :flat,
     reports_aggr: :aggregated,
     timeline: :aggregated,
+    timeline_posts: :aggregated,
+    timeline_media: :aggregated,
     notifications: :notification,
-    global: :aggregated
+    global: :aggregated,
+    global_posts: :aggregated,
+    global_media: :aggregated
   }.freeze
 
   attr_accessor :stream_feed, :group, :id
@@ -61,7 +71,7 @@ class Feed
     "#{group}:#{id}"
   end
 
-  FEED_GROUPS.keys.each do |feed|
+  FEED_GROUPS.except(:global, :global_media, :global_posts).keys.each do |feed|
     define_singleton_method(feed) { |*args| new(feed, args.join('-')) }
   end
 
@@ -71,6 +81,14 @@ class Feed
 
   def self.global
     new('global', 'global')
+  end
+
+  def self.global_posts
+    new('global_posts', 'global')
+  end
+
+  def self.global_media
+    new('global_media', 'global')
   end
 
   def type

--- a/app/models/feed/activity_list/page.rb
+++ b/app/models/feed/activity_list/page.rb
@@ -100,7 +100,7 @@ class Feed
               # If it's an array (nested enrichment), grab the top level
               key = key.first if key.is_a?(Array)
               # Delete if it's still a string
-              act.delete(key) if act[key].is_a?(String)
+              act.delete(key.to_s) if act[key.to_s].is_a?(String)
             end
           end
           act

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -40,11 +40,17 @@ class Follow < ApplicationRecord
   validate :validate_not_yourself
 
   after_create do
-    follower.timeline.follow(followed.feed)
+    follower.timeline.follow(followed.posts_feed)
+    follower.timeline.follow(followed.media_feed)
+    follower.posts_timeline.follow(followed.posts_feed)
+    follower.media_timeline.follow(followed.media_feed)
   end
 
   after_destroy do
-    follower.timeline.unfollow(followed.feed)
+    follower.timeline.unfollow(followed.posts_feed)
+    follower.timeline.unfollow(followed.media_feed)
+    follower.posts_timeline.unfollow(followed.posts_feed)
+    follower.media_timeline.unfollow(followed.media_feed)
   end
 
   after_create { follower.update_feed_completed! }

--- a/app/models/marathon_event.rb
+++ b/app/models/marathon_event.rb
@@ -33,9 +33,9 @@ class MarathonEvent < ActiveRecord::Base
   delegate :user, to: :library_entry
 
   def stream_activity
-    user.feed.activities.new(
+    user.media_feed.activities.new(
       updated_at: updated_at,
-      to: [media.feed],
+      to: [media.media_feed],
       verb: event.to_s,
       status: status.to_s
     )

--- a/app/models/media_follow.rb
+++ b/app/models/media_follow.rb
@@ -23,10 +23,16 @@ class MediaFollow < ActiveRecord::Base
   validates :media, polymorphism: { type: Media }
 
   after_create do
-    user.timeline.follow(media.feed)
+    user.timeline.follow(media.posts_feed)
+    user.timeline.follow(media.media_feed)
+    user.posts_timeline.follow(media.posts_feed)
+    user.media_timeline.follow(media.media_feed)
   end
 
   after_destroy do
-    user.timeline.unfollow(media.feed)
+    user.timeline.unfollow(media.posts_feed)
+    user.timeline.unfollow(media.media_feed)
+    user.posts_timeline.unfollow(media.posts_feed)
+    user.media_timeline.unfollow(media.media_feed)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -70,7 +70,7 @@ class Post < ApplicationRecord
   end
 
   def other_feeds
-    [media&.feed].compact
+    [media&.posts_feed].compact
   end
 
   def notified_feeds
@@ -82,11 +82,11 @@ class Post < ApplicationRecord
 
   def target_feed
     if target_user
-      target_user.aggregated_feed
+      target_user.posts_aggregated_feed
     elsif target_group
       target_group.feed
     else
-      user.feed
+      user.posts_feed
     end
   end
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -58,11 +58,11 @@ class Review < ApplicationRecord
   end
 
   def stream_activity
-    user.feed.activities.new(
+    user.media_feed.activities.new(
       progress: progress,
       updated_at: updated_at,
       likes_count: likes_count,
-      to: [media.feed]
+      to: [media.media_feed]
     )
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -111,7 +111,7 @@ class ApplicationPolicy
   # @return [Boolean] Whether the current user is the owner of the record
   def is_owner? # rubocop:disable Style/PredicateName
     return false unless user && record.respond_to?(:user)
-    return false unless record.user == user
+    return false unless record.user_id == user.id
     return false if record.user_id_was && record.user_id_was != user.id
     true
   end

--- a/app/services/media_activity_service.rb
+++ b/app/services/media_activity_service.rb
@@ -8,7 +8,7 @@ class MediaActivityService
   end
 
   def status(status)
-    fill_defaults user.feed.activities.new(
+    fill_defaults user.media_feed.activities.new(
       foreign_id: "LibraryEntry:#{library_entry.id}:updated-#{status}",
       verb: 'updated',
       status: status
@@ -16,7 +16,7 @@ class MediaActivityService
   end
 
   def rating(rating)
-    fill_defaults user.feed.activities.new(
+    fill_defaults user.media_feed.activities.new(
       foreign_id: "LibraryEntry:#{library_entry.id}:rated",
       verb: 'rated',
       rating: rating,
@@ -27,7 +27,7 @@ class MediaActivityService
 
   def progress(progress, unit = nil)
     return if progress.zero?
-    fill_defaults user.feed.activities.new(
+    fill_defaults user.media_feed.activities.new(
       verb: 'progressed',
       foreign_id: "LibraryEntry:#{library_entry.id}:progressed-#{progress}",
       progress: progress,
@@ -36,7 +36,7 @@ class MediaActivityService
   end
 
   def reviewed(review)
-    fill_defaults user.feed.activities.new(
+    fill_defaults user.media_feed.activities.new(
       foreign_id: review,
       verb: 'reviewed',
       review: review
@@ -48,7 +48,7 @@ class MediaActivityService
       act.actor ||= user
       act.object ||= library_entry
       act.to ||= []
-      act.to << media&.feed
+      act.to << media&.media_feed
       act.media ||= media
       act.nsfw ||= media.try(:nsfw?)
       act.foreign_id ||= library_entry

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,11 +15,13 @@ on_worker_boot do
 end
 
 before_fork do
-  PumaWorkerKiller.config do |config|
-    config.ram           = 1024  # mb
-    config.frequency     = 60    # seconds
-    config.percent_usage = 0.94
-    config.rolling_restart_frequency = 24 * 3600 # 12 hours in seconds
+  unless ENV['RACK_ENV'] == 'development'
+    PumaWorkerKiller.config do |config|
+      config.ram           = 1024  # mb
+      config.frequency     = 60    # seconds
+      config.percent_usage = 0.94
+      config.rolling_restart_frequency = 24 * 3600 # 12 hours in seconds
+    end
+    PumaWorkerKiller.start
   end
-  PumaWorkerKiller.start
 end

--- a/lib/tasks/stream.rake
+++ b/lib/tasks/stream.rake
@@ -1,12 +1,14 @@
+require 'stream_sync'
+
 namespace :stream do
   namespace :sync do
     desc 'Synchronize followers to Stream'
-    task :follows => :environment do
+    task follows: :environment do
       StreamSync.follows
     end
 
     desc 'Synchronize automatic (under-the-hood) follows to Stream'
-    task :auto_follows => :environment do
+    task auto_follows: :environment do
       StreamSync.follow_timeline
       StreamSync.follow_global
       StreamSync.follow_user_aggr
@@ -17,34 +19,34 @@ namespace :stream do
     end
 
     desc 'Synchronize media genres'
-    task :media_genres => :environment do
+    task media_genres: :environment do
       StreamSync.media_genres
     end
   end
 
   namespace :dump do
     desc 'Dump posts in the mass import format for Stream'
-    task :posts => :environment do
+    task posts: :environment do
       StreamDump.posts.each { |instr| STDOUT.puts instr.to_json }
     end
 
     desc 'Dump all stories in the mass import format for Stream'
-    task :stories => :environment do
+    task stories: :environment do
       StreamDump.stories.each { |instr| STDOUT.puts instr.to_json }
     end
 
     desc 'Dump automatic follows'
-    task :auto_follows => :environment do
+    task auto_follows: :environment do
       StreamDump.auto_follows.each { |instr| STDOUT.puts instr.to_json }
     end
 
     desc 'Dump follows'
-    task :follows => :environment do
+    task follows: :environment do
       StreamDump.follows.each { |instr| STDOUT.puts instr.to_json }
     end
 
     desc 'Dump group stuff'
-    task :groups => :environment do
+    task groups: :environment do
       ApplicationRecord.logger = Logger.new(nil)
       StreamDump.group_posts.each { |instr| STDOUT.puts instr.to_json }
       StreamDump.group_memberships.each { |instr| STDOUT.puts instr.to_json }

--- a/spec/models/feed/activity_list/page_spec.rb
+++ b/spec/models/feed/activity_list/page_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Feed::ActivityList::Page do
   let(:opts) { { feed: feed } }
 
   context 'on a flat feed' do
-    let(:feed) { Feed.user(1) }
+    let(:feed) { Feed.user_posts(1) }
     let(:data) do
       [
         { nsfw: true, actor: user.stream_id },

--- a/spec/models/feed_spec.rb
+++ b/spec/models/feed_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Feed, type: :model do
-  subject { Feed.new('user', '1') }
+  subject { Feed.new('user_aggr', '1') }
 
   it { should delegate_method(:readonly_token).to(:stream_feed) }
 
@@ -14,7 +14,7 @@ RSpec.describe Feed, type: :model do
 
   describe '#stream_id' do
     it 'should return the group and id separated by a colon' do
-      expect(subject.stream_id).to eq('user:1')
+      expect(subject.stream_id).to eq('user_aggr:1')
     end
   end
 
@@ -29,20 +29,20 @@ RSpec.describe Feed, type: :model do
     end
   end
 
-  describe '.user' do
-    subject { Feed.user(1) }
-    it 'should return a user feed' do
-      expect(subject.group).to eq('user')
+  describe '.user_aggr' do
+    subject { Feed.user_aggr(1) }
+    it 'should return a user aggregated feed' do
+      expect(subject.group).to eq('user_aggr')
     end
     it 'should have the id we gave' do
       expect(subject.id).to eq('1')
     end
   end
 
-  describe '.media' do
-    subject { Feed.media('anime', 123) }
-    it 'should return a media feed' do
-      expect(subject.group).to eq('media')
+  describe '.media_aggr' do
+    subject { Feed.media_aggr('anime', 123) }
+    it 'should return a media aggregated feed' do
+      expect(subject.group).to eq('media_aggr')
     end
     it 'should have the type and id we gave, separated by a hyphen' do
       expect(subject.id).to eq('anime-123')
@@ -65,8 +65,46 @@ RSpec.describe Feed, type: :model do
     end
   end
 
-  it 'should respond to .timeline and .notifications' do
-    expect(described_class).to respond_to(:timeline)
-    expect(described_class).to respond_to(:notifications)
+  describe 'available feeds' do
+    subject { described_class }
+
+    it { respond_to :user_posts }
+    it { respond_to :user_media }
+    it { respond_to :user_aggr }
+    it { respond_to :user_posts_aggr }
+    it { respond_to :user_media_aggr }
+    it { respond_to :media_posts }
+    it { respond_to :media_media }
+    it { respond_to :media_aggr }
+    it { respond_to :media_posts_aggr }
+    it { respond_to :media_media_aggr }
+    it { respond_to :group }
+    it { respond_to :group_aggr }
+    it { respond_to :post }
+    it { respond_to :reports_aggr }
+    it { respond_to :timeline }
+    it { respond_to :timeline_posts }
+    it { respond_to :timeline_media }
+    it { respond_to :notifications }
+  end
+
+  describe '.global' do
+    it 'returns the global feed' do
+      expect(described_class.global).to eq(Feed.new('global', 'global'))
+    end
+  end
+
+  describe '.global_posts' do
+    it 'returns the global posts feed' do
+      expect(described_class.global_posts)
+        .to eq(Feed.new('global_posts', 'global'))
+    end
+  end
+
+  describe '.global_media' do
+    it 'returns the global media feed' do
+      expect(described_class.global_media)
+        .to eq(Feed.new('global_media', 'global'))
+    end
   end
 end

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -21,6 +21,11 @@ require 'rails_helper'
 RSpec.describe Follow, type: :model do
   let(:user_follower) { create(:user) }
   let(:user_followed) { create(:user) }
+  let(:timeline) { double(:feed).as_null_object }
+
+  before do
+    allow(subject.follower).to receive(:timeline).and_return(timeline)
+  end
 
   subject { build(:follow, follower: user_follower, followed: user_followed) }
 
@@ -31,16 +36,55 @@ RSpec.describe Follow, type: :model do
     .counter_cache(:followers_count).touch(true) }
   it { should validate_presence_of(:followed) }
 
-  it "should add follow to follower's timeline on save" do
+  it "should add posts follow to follower's timeline on save" do
     expect(subject.follower.timeline).to receive(:follow)
-      .with(subject.followed.feed)
+      .with(subject.followed.posts_feed)
     subject.save!
   end
 
-  it "should remove follow on follower's timeline on destroy" do
+  it "should add media follow to follower's timeline on save" do
+    expect(subject.follower.timeline).to receive(:follow)
+      .with(subject.followed.media_feed)
+    subject.save!
+  end
+
+  it "should add follow to follower's posts timeline on save" do
+    expect(subject.follower.posts_timeline).to receive(:follow)
+      .with(subject.followed.posts_feed)
+    subject.save!
+  end
+
+  it "should add follow to follower's media timeline on save" do
+    expect(subject.follower.media_timeline).to receive(:follow)
+      .with(subject.followed.media_feed)
+    subject.save!
+  end
+
+  it "should remove posts follow on follower's timeline on destroy" do
     subject.save!
     expect(subject.follower.timeline).to receive(:unfollow)
-      .with(subject.followed.feed)
+      .with(subject.followed.posts_feed)
+    subject.destroy!
+  end
+
+  it "should remove media follow on follower's timeline on destroy" do
+    subject.save!
+    expect(subject.follower.timeline).to receive(:unfollow)
+      .with(subject.followed.media_feed)
+    subject.destroy!
+  end
+
+  it "should remove follow on follower's posts timeline on destroy" do
+    subject.save!
+    expect(subject.follower.posts_timeline).to receive(:unfollow)
+      .with(subject.followed.posts_feed)
+    subject.destroy!
+  end
+
+  it "should remove follow on follower's media timeline on destroy" do
+    subject.save!
+    expect(subject.follower.media_timeline).to receive(:unfollow)
+      .with(subject.followed.media_feed)
     subject.destroy!
   end
 
@@ -54,5 +98,10 @@ RSpec.describe Follow, type: :model do
   it "should generate an activity on the followers' aggregated feed" do
     follower_feed = subject.follower.aggregated_feed
     expect(subject.stream_activity.feed).to eq(follower_feed)
+  end
+
+  it "should copy the activity to the followed's notification feed" do
+    expect(subject.stream_activity[:to])
+      .to include(subject.followed.notifications)
   end
 end

--- a/spec/models/marathon_event_spec.rb
+++ b/spec/models/marathon_event_spec.rb
@@ -31,13 +31,18 @@ RSpec.describe MarathonEvent, type: :model do
     subject { build(:marathon_event, event: :updated)}
     it { should validate_presence_of(:status) }
   end
+
   context 'without event=changed' do
     subject { build(:marathon_event, event: :consumed) }
     it { should_not validate_presence_of(:status) }
   end
 
-  it 'should have an activity with media feed in "to" list' do
+  it 'should publish to the user\'s media feed' do
+    expect(subject.stream_activity.feed).to eq(subject.user.media_feed)
+  end
+
+  it 'should have an activity with media\'s media feed in "to" list' do
     activity = subject.stream_activity.as_json.with_indifferent_access
-    expect(activity[:to]).to include(subject.media.feed.stream_id)
+    expect(activity[:to]).to include(subject.media.media_feed.stream_id)
   end
 end

--- a/spec/models/media_follow_spec.rb
+++ b/spec/models/media_follow_spec.rb
@@ -19,6 +19,12 @@
 require 'rails_helper'
 
 RSpec.describe MediaFollow, type: :model do
+  let(:timeline) { double(:feed).as_null_object }
+
+  before do
+    allow(subject.user).to receive(:timeline).and_return(timeline)
+  end
+
   subject { build(:media_follow) }
 
   it { should belong_to(:user).touch(true) }
@@ -26,14 +32,55 @@ RSpec.describe MediaFollow, type: :model do
   it { should belong_to(:media) }
   it { should validate_presence_of(:media) }
 
-  it 'should send the follow to Stream on save' do
-    expect(subject.user.timeline).to receive(:follow).with(subject.media.feed)
+  it 'should follow the media posts feed on save' do
+    expect(subject.user.timeline).to receive(:follow)
+      .with(subject.media.posts_feed)
     subject.save!
   end
 
-  it 'should remove the follow from Stream on save' do
+  it 'should follow the media media feed on save' do
+    expect(subject.user.timeline).to receive(:follow)
+      .with(subject.media.media_feed)
     subject.save!
-    expect(subject.user.timeline).to receive(:unfollow).with(subject.media.feed)
+  end
+
+  it 'should follow the media posts feed for the posts timeline on save' do
+    expect(subject.user.posts_timeline).to receive(:follow)
+      .with(subject.media.posts_feed)
+    subject.save!
+  end
+
+  it 'should follow the media media feed for the media timeline on save' do
+    expect(subject.user.media_timeline).to receive(:follow)
+      .with(subject.media.media_feed)
+    subject.save!
+  end
+
+  it 'should unfollow the media posts feed on destroy' do
+    subject.save!
+    expect(subject.user.timeline).to receive(:unfollow)
+      .with(subject.media.posts_feed)
+    subject.destroy!
+  end
+
+  it 'should unfollow the media media feed on destroy' do
+    subject.save!
+    expect(subject.user.timeline).to receive(:unfollow)
+      .with(subject.media.media_feed)
+    subject.destroy!
+  end
+
+  it 'should unfollow the media posts feed for posts timeline on destroy' do
+    subject.save!
+    expect(subject.user.posts_timeline).to receive(:unfollow)
+      .with(subject.media.posts_feed)
+    subject.destroy!
+  end
+
+  it 'should unfollow the media media feed for media timeline on destroy' do
+    subject.save!
+    expect(subject.user.media_timeline).to receive(:unfollow)
+      .with(subject.media.media_feed)
     subject.destroy!
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -62,8 +62,8 @@ RSpec.describe Post, type: :model do
     subject { build(:post, media: media) }
     let(:activity) { subject.stream_activity.as_json.with_indifferent_access }
 
-    it 'should have an activity with media feed in "to" list' do
-      expect(activity[:to]).to include(media.feed.stream_id)
+    it 'should have an activity with media\'s posts feed in "to" list' do
+      expect(activity[:to]).to include(media.posts_feed.stream_id)
     end
   end
 
@@ -90,9 +90,10 @@ RSpec.describe Post, type: :model do
     let(:activity) { subject.stream_activity.as_json.with_indifferent_access }
 
     describe '#stream_activity' do
-      it "should have the target user's feed as the target" do
-        expect(subject.stream_activity.feed).to eq(user.aggregated_feed)
+      it "should have the target user's aggregated posts feed as the target" do
+        expect(subject.stream_activity.feed).to eq(user.posts_aggregated_feed)
       end
+
       it "should have the target user's notifications in the to field" do
         expect(activity[:to]).to include(user.notifications.stream_id)
       end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -35,7 +35,9 @@
 require 'rails_helper'
 
 RSpec.describe Review, type: :model do
-  subject { build(:review) }
+  let(:user) { build(:user, id: 1) }
+
+  subject { build(:review, user: user) }
   it { should have_many(:likes).class_name('ReviewLike') }
   it { should belong_to(:media) }
   it { should validate_presence_of(:media) }
@@ -48,4 +50,14 @@ RSpec.describe Review, type: :model do
   it { should belong_to(:library_entry) }
   it { should validate_presence_of(:library_entry) }
   it { should validate_presence_of(:content) }
+
+  describe '#steam_activity' do
+    it 'publishes the activity to the user\'s media feed' do
+      expect(subject.stream_activity.feed).to eq(subject.user.media_feed)
+    end
+
+    it 'copies the activity to the media\'s media feed' do
+      expect(subject.stream_activity[:to]).to include(subject.media.media_feed)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -93,7 +93,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  subject { build(:user) }
+  subject { build(:user, id: 1) }
   let(:persisted_user) { create(:user) }
 
   it { should have_db_index(:facebook_id) }
@@ -186,6 +186,215 @@ RSpec.describe User, type: :model do
         subject.save
       end
       expect(subject.past_names[0]).to equal(subject.previous_name)
+    end
+  end
+
+  describe 'available feeds' do
+    it 'include a user posts feed' do
+      expect(subject.posts_feed).to eq(Feed.user_posts(subject.id))
+    end
+
+    it 'include a user media feed' do
+      expect(subject.media_feed).to eq(Feed.user_media(subject.id))
+    end
+
+    it 'include a user aggregated feed' do
+      expect(subject.aggregated_feed).to eq(Feed.user_aggr(subject.id))
+    end
+
+    it 'include a user posts aggregated feed' do
+      expect(subject.posts_aggregated_feed)
+        .to eq(Feed.user_posts_aggr(subject.id))
+    end
+
+    it 'include a user media aggregated feed' do
+      expect(subject.media_aggregated_feed)
+        .to eq(Feed.user_media_aggr(subject.id))
+    end
+
+    it 'include a timeline feed' do
+      expect(subject.timeline).to eq(Feed.timeline(subject.id))
+    end
+
+    it 'include a posts timeline feed' do
+      expect(subject.posts_timeline).to eq(Feed.timeline_posts(subject.id))
+    end
+
+    it 'include a media timeline feed' do
+      expect(subject.media_timeline).to eq(Feed.timeline_media(subject.id))
+    end
+
+    it 'include a notifications feed' do
+      expect(subject.notifications).to eq(Feed.notifications(subject.id))
+    end
+  end
+
+  describe 'after creation' do
+    before do
+      allow_any_instance_of(Feed).to receive(:follow)
+      allow_any_instance_of(Feed).to receive(:unfollow)
+    end
+
+    context 'setting up the aggregated feed follows' do
+      let(:aggregated_feed) { double(:feed).as_null_object }
+
+      before do
+        allow(subject).to receive(:aggregated_feed).and_return(aggregated_feed)
+      end
+
+      it 'sets user aggregated feed to follow the user posts feed' do
+        expect(subject.aggregated_feed)
+          .to receive(:follow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'sets user aggregated feed to follow the user media feed' do
+        expect(subject.aggregated_feed)
+          .to receive(:follow).with(subject.media_feed)
+        subject.save!
+      end
+    end
+
+    it 'sets user posts aggregated feed to follow the user posts feed' do
+      expect(subject.posts_aggregated_feed).to receive(:follow)
+        .with(subject.posts_feed)
+      subject.save!
+    end
+
+    it 'sets user media aggregated feed to follow the user media feed' do
+      expect(subject.media_aggregated_feed).to receive(:follow)
+        .with(subject.media_feed)
+      subject.save!
+    end
+
+    context 'setting up the timeline follows' do
+      let(:timeline) { double(:feed).as_null_object }
+
+      before do
+        allow(subject).to receive(:timeline).and_return(timeline)
+      end
+
+      it 'sets the timeline feed to follow the user posts feed' do
+        expect(subject.timeline).to receive(:follow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'sets the timeline feed to follow the user media feed' do
+        expect(subject.timeline).to receive(:follow).with(subject.media_feed)
+        subject.save!
+      end
+    end
+
+    it 'sets the posts timeline feed to follow the user posts feed' do
+      expect(subject.posts_timeline).to receive(:follow)
+        .with(subject.posts_feed)
+      subject.save!
+    end
+
+    it 'sets the media timeline feed to follow the user media feed' do
+      expect(subject.media_timeline).to receive(:follow)
+        .with(subject.media_feed)
+      subject.save!
+    end
+
+    context 'setting up global feeds' do
+      let(:global) { double(:feed).as_null_object }
+      let(:global_posts) { double(:feed).as_null_object }
+      let(:global_media) { double(:feed).as_null_object }
+
+      before do
+        allow(Feed).to receive(:global).and_return(global)
+        allow(Feed).to receive(:global_posts).and_return(global_posts)
+        allow(Feed).to receive(:global_media).and_return(global_media)
+      end
+
+      it 'sets the global feed to follow the user posts feed' do
+        expect(global).to receive(:follow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'sets the global feed to follow the user media feed' do
+        expect(global).to receive(:follow).with(subject.media_feed)
+        subject.save!
+      end
+
+      it 'sets the global posts feed to follow the user posts feed' do
+        expect(global_posts).to receive(:follow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'sets the global media feed to follow the user media feed' do
+        expect(global_media).to receive(:follow).with(subject.media_feed)
+        subject.save!
+      end
+    end
+  end
+
+  describe 'after updating' do
+    let(:global) { double(:feed).as_null_object }
+    let(:global_posts) { double(:feed).as_null_object }
+    let(:global_media) { double(:feed).as_null_object }
+
+    before do
+      allow(Feed).to receive(:global).and_return(global)
+      allow(Feed).to receive(:global_posts).and_return(global_posts)
+      allow(Feed).to receive(:global_media).and_return(global_media)
+    end
+
+    context 'when global sharing changes to true' do
+      before do
+        subject.share_to_global = false
+        subject.save!
+        subject.share_to_global = true
+      end
+
+      it 'sets the global feed to follow the user posts feed' do
+        expect(global).to receive(:follow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'sets the global feed to follow the user media feed' do
+        expect(global).to receive(:follow).with(subject.media_feed)
+        subject.save!
+      end
+
+      it 'sets the global posts feed to follow the user posts feed' do
+        expect(global_posts).to receive(:follow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'sets the global media feed to follow the user media feed' do
+        expect(global_media).to receive(:follow).with(subject.media_feed)
+        subject.save!
+      end
+    end
+
+    context 'when global sharing changes to false' do
+      before do
+        subject.share_to_global = true
+        subject.save!
+        subject.share_to_global = false
+      end
+
+      it 'unsets the global feed from following the user posts feed' do
+        expect(global).to receive(:unfollow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'unsets the global feed from following the user media feed' do
+        expect(global).to receive(:unfollow).with(subject.media_feed)
+        subject.save!
+      end
+
+      it 'unsets the global posts feed from following the user posts feed' do
+        expect(global_posts).to receive(:unfollow).with(subject.posts_feed)
+        subject.save!
+      end
+
+      it 'unsets the global media feed from following the user media feed' do
+        expect(global_media).to receive(:unfollow).with(subject.media_feed)
+        subject.save!
+      end
     end
   end
 end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe CommentPolicy do
-  let(:owner) { token_for build(:user) }
-  let(:other) { token_for build(:user) }
+  let(:owner) { token_for build(:user, id: 1) }
+  let(:other) { token_for build(:user, id: 2) }
   let(:admin) { token_for create(:user, :admin) }
   let(:comment) { build(:comment, user: owner.resource_owner) }
   subject { described_class }

--- a/spec/policies/favorite_policy_spec.rb
+++ b/spec/policies/favorite_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe FavoritePolicy do
-  let(:owner) { token_for build(:user) }
-  let(:other) { token_for build(:user) }
+  let(:owner) { token_for build(:user, id: 1) }
+  let(:other) { token_for build(:user, id: 2) }
   let(:favorite) { build(:favorite, user: owner.resource_owner) }
   subject { described_class }
 

--- a/spec/policies/library_entry_policy_spec.rb
+++ b/spec/policies/library_entry_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe LibraryEntryPolicy do
-  let(:owner) { token_for build(:user) }
-  let(:user) { token_for build(:user) }
+  let(:owner) { token_for build(:user, id: 1) }
+  let(:user) { token_for build(:user, id: 2) }
   let(:admin) { token_for create(:user, :admin) }
   let(:entry) { build(:library_entry, user: owner.resource_owner) }
   subject { described_class }

--- a/spec/policies/linked_account_policy_spec.rb
+++ b/spec/policies/linked_account_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe LinkedAccountPolicy do
-  let(:owner) { token_for build(:user) }
-  let(:user) { token_for build(:user) }
+  let(:owner) { token_for build(:user, id: 1) }
+  let(:user) { token_for build(:user, id: 2) }
   let(:admin) { token_for create(:user, :admin) }
   let(:linked_account) do
     build(:linked_account, user: owner.resource_owner)

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe PostPolicy do
-  let(:owner) { token_for build(:user) }
-  let(:other) { token_for build(:user) }
+  let(:owner) { token_for build(:user, id: 1) }
+  let(:other) { token_for build(:user, id: 2) }
   let(:admin) { token_for create(:user, :admin) }
   let(:post) { build(:post, user: owner.resource_owner) }
   subject { described_class }

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe ReportPolicy do
-  let(:user) { token_for build(:user) }
-  let(:other) { token_for build(:user) }
+  let(:user) { token_for build(:user, id: 1) }
+  let(:other) { token_for build(:user, id: 2) }
   let(:admin) { token_for create(:user, :admin) }
   let(:report) { build(:report, user: user.resource_owner) }
   subject { described_class }

--- a/spec/services/feed_query_service_spec.rb
+++ b/spec/services/feed_query_service_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe FeedQueryService do
+  let(:user) { build(:user) }
+
+  subject { FeedQueryService.new(params, user) }
+
+  describe '#feed' do
+    shared_examples_for 'a feed generator' do |group, id|
+      let(:params) do
+        {
+          'group' => group,
+          'id' => id,
+          'filters' => { 'kind' => kind }
+        }.with_indifferent_access
+      end
+
+      context 'when kind is not set' do
+        let(:kind) { nil }
+
+        it 'returns the corresponding general feed' do
+          expect(subject.feed).to eq(Feed.new(group, id))
+        end
+      end
+
+      context 'when kind is set to posts' do
+        let(:kind) { 'posts' }
+
+        it 'returns the corresponding posts feed' do
+          expect(subject.feed).to eq(Feed.new(group, id))
+        end
+      end
+
+      context 'when kind is set to media' do
+        let(:kind) { 'media' }
+
+        it 'returns the corresponding media feed' do
+          expect(subject.feed).to eq(Feed.new(group, id))
+        end
+      end
+    end
+
+    context 'when feed is global' do
+      it_behaves_like 'a feed generator', 'global', 'global'
+    end
+
+    context 'when feed is timeline' do
+      it_behaves_like 'a feed generator', 'timeline', '1'
+    end
+
+    context 'when feed is user_aggr' do
+      it_behaves_like 'a feed generator', 'user_aggr', '1'
+    end
+
+    context 'when feed is media_aggr' do
+      it_behaves_like 'a feed generator', 'media_aggr', '1'
+    end
+  end
+end

--- a/spec/services/media_activity_service_spec.rb
+++ b/spec/services/media_activity_service_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe MediaActivityService do
+  let(:library_entry) { build(:library_entry, user: build(:user, id: 1)) }
+
+  subject { described_class.new(library_entry) }
+
+  describe '#status' do
+    it 'returns an activity for the user\'s media feed' do
+      expect(subject.status('current').feed)
+        .to eq(library_entry.user.media_feed)
+    end
+  end
+
+  describe '#rating' do
+    it 'returns an activity for the user\'s media feed' do
+      expect(subject.rating(5).feed)
+        .to eq(library_entry.user.media_feed)
+    end
+  end
+
+  describe '#progress' do
+    it 'returns an activity for the user\'s media feed' do
+      expect(subject.progress(1).feed)
+        .to eq(library_entry.user.media_feed)
+    end
+  end
+
+  describe '#reviewed' do
+    let(:review) { build(:review, library_entry: library_entry) }
+
+    it 'returns an activity for the user\'s media feed' do
+      expect(subject.reviewed(review).feed)
+        .to eq(library_entry.user.media_feed)
+    end
+  end
+end


### PR DESCRIPTION
* Use split feeds to filter activity
* Creating users and media sets the correct follows between feeds
* User activity gets created into the corresponding filtered feed
* Updated Stream Sync Rake tasks to point (and repoint) feeds correctly
* BONUS: Fix code cleaning up unenriched keys (was ignoring symbols)
* BONUS: Check resource permissions based on user ID and not object identity
* BONUS: Set `activity_copy_limit` parameter to 300 as 1000 is not supported for batch follows (Stream API bug)