### PR TITLE
Rails admin config fixes

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -31,7 +31,7 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
     delete
     history_show
     show_in_app do
-      only ['Anime', 'Manga', 'Groups', 'User']
+      only %w[Anime Manga Groups User]
     end
   end
 

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -76,7 +76,14 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   end
   config.model('MangaCharacter') { parent Manga }
   config.model('MangaStaff') { parent Manga }
-  config.model('Chapter') { parent Manga }
+  config.model 'Chapter' do
+    parent Manga
+    field :manga_id
+    field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
+    fields :canonical_title, :number, :synopsis, :published, :volume, :length
+    include_all_fields
+    navigation_label 'Chapters'
+  end
   # Drama
   config.model 'Drama' do
     field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -52,7 +52,7 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
       html_attributes rows: '6', cols: '70'
     end
     fields :canonical_title, :synopsis, :slug, :subtype, :poster_image,
-      :cover_image, :age_rating, :age_rating_guide
+      :cover_image, :age_rating, :age_rating_guide, :episode_count
     include_all_fields
     exclude_fields :library_entries, :inverse_media_relationships, :favorites,
       :producers, :average_rating, :cover_image_top_offset
@@ -70,7 +70,8 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
       html_attributes rows: '6', cols: '70'
     end
     fields :canonical_title, :synopsis, :slug, :subtype, :poster_image,
-      :cover_image, :age_rating, :age_rating_guide
+      :cover_image, :age_rating, :age_rating_guide, :chapter_count,
+      :volume_count
     include_all_fields
     exclude_fields :library_entries, :inverse_media_relationships, :favorites,
       :average_rating, :cover_image_top_offset

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -30,6 +30,9 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
     edit
     delete
     history_show
+    show_in_app do
+      only ['Anime', 'Manga', 'Groups', 'User']
+    end
   end
 
   # Display canonical_title for label on media

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -131,7 +131,8 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
       :dropbox_token, :dropbox_secret, :last_backup, :stripe_token,
       :stripe_customer_id, :import_status, :import_from, :import_error,
       :profile_completed, :feed_completed, :followers, :following, :comments,
-      :posts, :media_follows, :blocks, :last_recommendations_update, :title
+      :posts, :media_follows, :blocks, :last_recommendations_update, :title,
+      :library_entries
     navigation_label 'Users'
     weight(-10)
   end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -82,7 +82,7 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   config.model('MangaStaff') { parent Manga }
   config.model 'Chapter' do
     parent Manga
-    field :manga_id
+    field :manga
     field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
     fields :canonical_title, :number, :synopsis, :published, :volume, :length
     include_all_fields


### PR DESCRIPTION
- Configured the chapter model so the `titles` field should show up properly
- Added the "Show in App" links which should link directly to Kitsu pages
- Added the missing episode, chapter, and volume count fields to the anime and manga models
- Excluded the `library_entries` field from the user model (I think it will fix a crash similar to the ones that were happening with manga)