### PR TITLE
Remove synopsis validation in episode model

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -36,7 +36,6 @@ class Episode < ApplicationRecord
   validates :media, presence: true, polymorphism: { type: Media }
   validates :number, presence: true
   validates :season_number, presence: true
-  validates :synopsis, length: { in: 50..600 }, allow_blank: true
   validates_attachment :thumbnail, content_type: {
     content_type: %w[image/jpg image/jpeg image/png]
   }

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe Episode, type: :model do
   it { should validate_presence_of(:media) }
   it { should validate_presence_of(:number) }
   it { should validate_presence_of(:season_number) }
-  it { should validate_length_of(:synopsis).is_at_least(50).is_at_most(600) }
   it 'should strip XSS from synopsis' do
     subject.synopsis = '<script>prompt("PASSWORD:")</script>' * 3
     subject.save!


### PR DESCRIPTION
The episode data in the db has synopses exceeding the 600 character limit which makes it impossible to edit through rails admin unless I shorten/remove it. Seeing as the synopsis field in the anime, manga, and chapter models aren't restricted, I think it should be fine if the restriction for episodes is removed.