### PR TITLE
Removing giphy.com from filter

### DIFF
--- a/app/pipelines/long_pipeline.rb
+++ b/app/pipelines/long_pipeline.rb
@@ -1,10 +1,12 @@
 require_dependency 'html/pipeline/inline_markdown_filter'
 require_dependency 'html/pipeline/kitsu_mention_filter'
+require_dependency 'html/pipeline/onebox_filter'
 
 LongPipeline = HTML::Pipeline.new [
   HTML::Pipeline::InlineMarkdownFilter,
   HTML::Pipeline::SanitizationFilter,
   HTML::Pipeline::KitsuMentionFilter,
-  HTML::Pipeline::AutolinkFilter
+  HTML::Pipeline::AutolinkFilter,
+  HTML::Pipeline::OneboxFilter
 ], base_url: '/user/',
    link_attr: 'target="_blank" rel="nofollow" class="autolink"'

--- a/lib/html/pipeline/onebox_filter.rb
+++ b/lib/html/pipeline/onebox_filter.rb
@@ -1,11 +1,11 @@
 module HTML
   class Pipeline
     class OneboxFilter < HTML::Pipeline::Filter
-      WHITELISTED_FILE_TYPES = ['.gif', '.jpg', '.png', '.mov', '.mp4']
+      ONEBOX_WHITELIST = ['.gif', '.jpg', '.jpeg', '.png', '.mov', '.mp4', 'giphy.com', 'gph.is', 'imgur.com']
       def call
         doc.search('a.autolink').each do |a|
           url = a['href']
-          file_regex = Regexp.union(WHITELISTED_FILE_TYPES)
+          file_regex = Regexp.union(ONEBOX_WHITELIST)
           if file_regex === url.downcase
             preview = Onebox.preview(url, max_width: 500) rescue nil
             if preview&.to_s.present?

--- a/lib/html/pipeline/onebox_filter.rb
+++ b/lib/html/pipeline/onebox_filter.rb
@@ -4,7 +4,8 @@ module HTML
       ONEBOX_WHITELIST = [
         '.gif', '.jpg', '.jpeg',
         '.png', '.mov', '.mp4',
-        'giphy.com', 'gph.is', 'imgur.com'
+        'giphy.com', 'gph.is', 'imgur.com',
+        '.webm'
       ].freeze
       def call
         doc.search('a.autolink').each do |a|

--- a/lib/html/pipeline/onebox_filter.rb
+++ b/lib/html/pipeline/onebox_filter.rb
@@ -1,8 +1,9 @@
 module HTML
   class Pipeline
     class OneboxFilter < HTML::Pipeline::Filter
-      ONEBOX_WHITELIST = ['.gif', '.jpg', '.jpeg', 
-        '.png', '.mov', '.mp4', 
+      ONEBOX_WHITELIST = [
+        '.gif', '.jpg', '.jpeg',
+        '.png', '.mov', '.mp4',
         'giphy.com', 'gph.is', 'imgur.com'
       ].freeze
       def call

--- a/lib/html/pipeline/onebox_filter.rb
+++ b/lib/html/pipeline/onebox_filter.rb
@@ -1,25 +1,27 @@
 module HTML
   class Pipeline
     class OneboxFilter < HTML::Pipeline::Filter
-      ONEBOX_WHITELIST = ['.gif', '.jpg', '.jpeg', '.png', '.mov', '.mp4', 'giphy.com', 'gph.is', 'imgur.com']
+      ONEBOX_WHITELIST = ['.gif', '.jpg', '.jpeg', 
+        '.png', '.mov', '.mp4', 
+        'giphy.com', 'gph.is', 'imgur.com'
+      ].freeze
       def call
         doc.search('a.autolink').each do |a|
           url = a['href']
           file_regex = Regexp.union(ONEBOX_WHITELIST)
-          if file_regex === url.downcase
-            preview = Onebox.preview(url, max_width: 500) rescue nil
-            if preview&.to_s.present?
-              onebox_name = preview.send(:engine).class.onebox_name
-              if onebox_name == 'whitelistedgeneric'
-                onebox_name = URI.parse(url).host.split('.')[-2..-1].join('-')
-              end
-              preview = Nokogiri::HTML5.fragment(preview.to_s)
-              a.swap <<-EOF.squish
-                <div class="onebox onebox-#{onebox_name}">
-                  #{preview}
-                </div>
-              EOF
+          next unless file_regex === url.downcase
+          preview = Onebox.preview(url, max_width: 500) rescue nil
+          if preview&.to_s.present?
+            onebox_name = preview.send(:engine).class.onebox_name
+            if onebox_name == 'whitelistedgeneric'
+              onebox_name = URI.parse(url).host.split('.')[-2..-1].join('-')
             end
+            preview = Nokogiri::HTML5.fragment(preview.to_s)
+            a.swap <<-EOF.squish
+              <div class="onebox onebox-#{onebox_name}">
+                #{preview}
+              </div>
+            EOF
           end
         end
         doc

--- a/lib/html/pipeline/onebox_filter.rb
+++ b/lib/html/pipeline/onebox_filter.rb
@@ -1,21 +1,25 @@
 module HTML
   class Pipeline
     class OneboxFilter < HTML::Pipeline::Filter
+      WHITELISTED_FILE_TYPES = ['.gif', '.jpg', '.png', '.mov', '.mp4']
       def call
         doc.search('a.autolink').each do |a|
           url = a['href']
-          preview = Onebox.preview(url, max_width: 500) rescue nil
-          if preview&.to_s.present?
-            onebox_name = preview.send(:engine).class.onebox_name
-            if onebox_name == 'whitelistedgeneric'
-              onebox_name = URI.parse(url).host.split('.')[-2..-1].join('-')
+          file_regex = Regexp.union(WHITELISTED_FILE_TYPES)
+          if file_regex === url.downcase
+            preview = Onebox.preview(url, max_width: 500) rescue nil
+            if preview&.to_s.present?
+              onebox_name = preview.send(:engine).class.onebox_name
+              if onebox_name == 'whitelistedgeneric'
+                onebox_name = URI.parse(url).host.split('.')[-2..-1].join('-')
+              end
+              preview = Nokogiri::HTML5.fragment(preview.to_s)
+              a.swap <<-EOF.squish
+                <div class="onebox onebox-#{onebox_name}">
+                  #{preview}
+                </div>
+              EOF
             end
-            preview = Nokogiri::HTML5.fragment(preview.to_s)
-            a.swap <<-EOF.squish
-              <div class="onebox onebox-#{onebox_name}">
-                #{preview}
-              </div>
-            EOF
           end
         end
         doc

--- a/lib/html/pipeline/onebox_filter.rb
+++ b/lib/html/pipeline/onebox_filter.rb
@@ -4,8 +4,7 @@ module HTML
       ONEBOX_WHITELIST = [
         '.gif', '.jpg', '.jpeg',
         '.png', '.mov', '.mp4',
-        'giphy.com', 'gph.is', 'imgur.com',
-        '.webm'
+        'gph.is', 'imgur.com', '.webm'
       ].freeze
       def call
         doc.search('a.autolink').each do |a|


### PR DESCRIPTION
We may want to think about just forking onebox, api changes will eventually happen and @NuckChorris pointed out that commits upstream has been dropping off on it.