### PR TITLE
Fix issues with library bulk API

### DIFF
--- a/app/models/library_entry.rb
+++ b/app/models/library_entry.rb
@@ -164,6 +164,10 @@ class LibraryEntry < ApplicationRecord
     end
   end
 
+  before_destroy do
+    review&.update_attribute(:library_entry_id, nil)
+  end
+
   before_save do
     if status_changed? && completed? && media&.progress_limit
       # When marked completed, we try to update progress to the cap


### PR DESCRIPTION
- Permits parameters to fix ForbiddenAttributesError error
- Calls `#update` on each individual record, which is what rails 5 does.
- Serialize updated entries using JR
- Render 204 NO CONTENT for deleted endpoint
- Null out reference to linked review if it exists

/ping @NuckChorris 