### PR TITLE
Fix issues with User Deletion

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -134,7 +134,20 @@ class User < ApplicationRecord
   has_many :post_follows, dependent: :destroy
   has_many :review_likes, dependent: :destroy
   has_many :list_imports, dependent: :destroy
+  has_many :group_action_logs, dependent: :destroy
+  has_many :group_bans, dependent: :destroy
+  has_many :group_invites, dependent: :destroy
   has_many :group_members, dependent: :destroy
+  has_many :group_reports
+  has_many :group_reports_as_moderator, class_name: 'GroupReport',
+                                        foreign_key: 'moderator_id'
+  has_many :group_ticket_messages, dependent: :destroy
+  has_many :group_tickets, dependent: :destroy
+  has_many :leader_chat_messages, dependent: :destroy
+  has_many :reports
+  has_many :reports_as_moderator, class_name: 'Report',
+                                  foreign_key: 'moderator_id'
+  has_many :site_announcements
   has_many :stats, dependent: :destroy
 
   validates :email, presence: true,
@@ -289,9 +302,14 @@ class User < ApplicationRecord
   before_destroy do
     # Destroy personal posts
     posts.where(target_group: nil, target_user: nil, media: nil).destroy_all
-    # Reparent other posts to the "Deleted" user
+    # Reparent relationships to the "Deleted" user
     posts.update_all(user_id: -10)
     comments.update_all(user_id: -10)
+    group_reports.update_all(user_id: -10)
+    group_reports_as_moderator.update_all(moderator_id: -10)
+    reports.update_all(user_id: -10)
+    reports_as_moderator.update_all(moderator_id: -10)
+    site_announcements.update_all(user_id: -10)
   end
 
   after_commit on: :create do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,7 +176,6 @@ class User < ApplicationRecord
   validates :password_digest, presence: true
   validates :facebook_id, uniqueness: true, allow_nil: true
 
-  default_scope -> { where(deleted_at: nil) }
   scope :by_name, ->(*names) {
     where('lower(users.name) IN (?)', names.flatten.map(&:downcase))
   }

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -33,7 +33,7 @@ class UserPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.blocking(blocked_users)
+      scope.where(deleted_at: nil).blocking(blocked_users)
     end
   end
 end


### PR DESCRIPTION
This still has issues I haven't addressed @NuckChorris.

Sidekiq workers are failing due to models such as `Follow` attempting to unfollow feeds and using the `default_scope` of the user.

What do you think the best way to fix that is? Out of a few tests, it seems the only way I got it to work was:

```ruby
belongs_to :follower, -> { unscope(where: :deleted_at) }, ...
```

_note: `-> { unscoped }` doesn't seem to work due to a rails bug_

But, that seems _incorrect_.