### PR TITLE
🎬 	Sync start_dates and end_dates for 1 unit media

### DIFF
--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -110,4 +110,11 @@ class Anime < ApplicationRecord
       prefix_length: 2
     }).preload.first
   end
+
+  before_save do
+    if episode_count == 1
+      self.start_date = end_date if start_date.nil? && !end_date.nil?
+      self.end_date = start_date if end_date.nil? && !start_date.nil?
+    end
+  end
 end

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -68,4 +68,11 @@ class Manga < ApplicationRecord
       -> { [canonical_title, year, subtype] } # attack-on-titan-2004-doujin
     ]
   end
+
+  before_save do
+    if chapter_count == 1
+      self.start_date = end_date if start_date.nil? && !end_date.nil?
+      self.end_date = start_date if end_date.nil? && !start_date.nil?
+    end
+  end
 end

--- a/db/migrate/20170601214239_backfill_media_dates.rb
+++ b/db/migrate/20170601214239_backfill_media_dates.rb
@@ -1,0 +1,28 @@
+require 'update_in_batches'
+
+class BackfillMediaDates < ActiveRecord::Migration
+  using UpdateInBatches
+  self.disable_ddl_transaction!
+
+  def change
+    Anime.where(episode_count: 1)
+         .where(start_date: nil)
+         .where.not(end_date: nil)
+         .update_in_batches('start_date = end_date')
+
+    Anime.where(episode_count: 1)
+         .where(end_date: nil)
+         .where.not(start_date: nil)
+         .update_in_batches('end_date = start_date')
+
+    Manga.where(chapter_count: 1)
+         .where(start_date: nil)
+         .where.not(end_date: nil)
+         .update_in_batches('start_date = end_date')
+
+    Manga.where(chapter_count: 1)
+         .where(end_date: nil)
+         .where.not(start_date: nil)
+         .update_in_batches('end_date = start_date')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170531082123) do
+ActiveRecord::Schema.define(version: 20170601214239) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"


### PR DESCRIPTION
this prevents treating media with 1 unit that were already aired/published as current.