### PR TITLE
Chewy - media index: add favorites count

### DIFF
--- a/app/chewy/media_index.rb
+++ b/app/chewy/media_index.rb
@@ -68,6 +68,7 @@ class MediaIndex < Chewy::Index
       field :genres, value: ->(a) { a.genres.map(&:name) }
       field :categories, value: ->(a) { a.categories.map(&:title) }
       field :user_count, type: 'integer'
+      field :favorites_count, type: 'integer'
       # Castings
       field :people, value: ->(a, crutch) { crutch.people[a.id] }
       field :characters, value: ->(a, crutch) { crutch.characters[a.id] }

--- a/app/chewy/media_index.rb
+++ b/app/chewy/media_index.rb
@@ -69,6 +69,7 @@ class MediaIndex < Chewy::Index
       field :categories, value: ->(a) { a.categories.map(&:title) }
       field :user_count, type: 'integer'
       field :favorites_count, type: 'integer'
+      field :popularity_rank, type: 'integer'
       # Castings
       field :people, value: ->(a, crutch) { crutch.people[a.id] }
       field :characters, value: ->(a, crutch) { crutch.characters[a.id] }


### PR DESCRIPTION
PR for https://github.com/hummingbird-me/hummingbird/issues/795 issue.
It adds field 'favorites_count' in chewy to allow use this field in sort request, at the same time there is a filter being applied.

Please review, thanks!
