### PR TITLE
Switch from acts_as_list to ranked-model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'rinku'
 gem 'sanitize'
 
 # Miscellaneous Utilities
-gem 'acts_as_list' # Sortables!
 gem 'addressable' # Fancy address logic
 gem 'counter_culture' # Fancier counter caches
 gem 'friendly_id' # slug-urls-are-cool
@@ -54,6 +53,7 @@ gem 'lograge' # Non-shitty logging
 gem 'mechanize' # Automating interaction with websites
 gem 'nokogiri', '~> 1.7.1' # Parse MAL XML shit
 gem 'paranoia', '~> 2.0' # Faux deletion
+gem 'ranked-model' # Sortables!
 gem 'ruby-progressbar' # Fancy progress bars for Rake tasks
 gem 'sitemap_generator' # Generate Sitemaps
 gem 'stream-ruby', '~> 2.5.4' # Feeds

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,6 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    acts_as_list (0.9.4)
-      activerecord (>= 3.0)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     after_commit_action (1.0.1)
@@ -390,6 +388,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.3.0)
+    ranked-model (0.4.0)
+      activerecord (>= 3.1.12)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -536,7 +536,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  acts_as_list
   addressable
   annotate
   attr_encrypted (~> 3.0.0)
@@ -589,6 +588,7 @@ DEPENDENCIES
   rails-api
   rails_12factor
   rails_admin
+  ranked-model
   redis (> 3.3.0)
   redis-rails
   rinku

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -21,7 +21,8 @@
 # rubocop:enable Metrics/LineLength
 
 class Favorite < ApplicationRecord
-  acts_as_list column: 'fav_rank', scope: %i[user_id item_type]
+  include RankedModel
+  ranks :fav_rank, with_same: %i[user_id item_type]
 
   belongs_to :user, required: true, counter_cache: true
   belongs_to :item, polymorphic: true, required: true

--- a/app/models/installment.rb
+++ b/app/models/installment.rb
@@ -20,7 +20,8 @@
 # rubocop:enable Metrics/LineLength
 
 class Installment < ApplicationRecord
-  acts_as_list
+  include RankedModel
+  ranks :position
 
   validates :tag, length: { maximum: 40 }
   validates :media, polymorphism: { type: Media }

--- a/app/resources/favorite_resource.rb
+++ b/app/resources/favorite_resource.rb
@@ -18,10 +18,14 @@ class FavoriteResource < BaseResource
   end
 
   def fav_rank
-    _model.fav_rank_position || _model.fav_rank
+    if _model.fav_rank_position
+      _model.fav_rank_position + 1
+    else
+      _model.fav_rank
+    end
   end
 
   def fav_rank=(val)
-    _model.fav_rank_position = val
+    _model.fav_rank_position = (val - 1)
   end
 end

--- a/app/resources/favorite_resource.rb
+++ b/app/resources/favorite_resource.rb
@@ -17,6 +17,10 @@ class FavoriteResource < BaseResource
     SQL
   end
 
+  def fav_rank
+    _model.fav_rank_position || _model.fav_rank
+  end
+
   def fav_rank=(val)
     _model.fav_rank_position = val
   end

--- a/app/resources/favorite_resource.rb
+++ b/app/resources/favorite_resource.rb
@@ -19,7 +19,13 @@ class FavoriteResource < BaseResource
 
   def fav_rank
     if _model.fav_rank_position
-      _model.fav_rank_position + 1
+      case _model.fav_rank_position
+      when :first then 1
+      when :last then 9_999_999
+      when :up, :down then nil
+      when Integer then _model.fav_rank_position + 1
+      else _model.fav_rank
+      end
     else
       _model.fav_rank
     end

--- a/app/resources/favorite_resource.rb
+++ b/app/resources/favorite_resource.rb
@@ -5,4 +5,19 @@ class FavoriteResource < BaseResource
   has_one :item, polymorphic: true
 
   filters :user_id, :item_type, :item_id
+
+  def self.find_records(filters, opts = {})
+    super(filters, opts).select(<<-SQL.squish)
+      *, (
+        row_number() OVER (
+          PARTITION BY user_id, item_type
+          ORDER BY fav_rank ASC
+        ) - 1
+      ) AS fav_rank
+    SQL
+  end
+
+  def fav_rank=(val)
+    _model.fav_rank_position = val
+  end
 end

--- a/db/migrate/20170501234913_space_out_ranks_for_favorites.rb
+++ b/db/migrate/20170501234913_space_out_ranks_for_favorites.rb
@@ -1,0 +1,26 @@
+require 'update_in_batches'
+
+class SpaceOutRanksForFavorites < ActiveRecord::Migration
+  using UpdateInBatches
+
+  disable_ddl_transaction!
+
+  def change
+    execute <<-SQL.squish
+      CREATE TEMPORARY VIEW fav_ranks (id, rank) AS
+        SELECT id, ((row_number() OVER (
+          PARTITION BY user_id, item_type
+          ORDER BY fav_rank ASC,
+                   created_at ASC
+        )) * 20) AS rank
+        FROM favorites
+    SQL
+    say_with_time 'Updating rank column for favorites' do
+      Favorite.all.update_in_batches(<<-SQL.squish)
+        fav_rank = (
+          SELECT rank FROM fav_ranks WHERE fav_ranks.id = favorites.id
+        )
+      SQL
+    end
+  end
+end

--- a/db/migrate/20170501234913_space_out_ranks_for_favorites.rb
+++ b/db/migrate/20170501234913_space_out_ranks_for_favorites.rb
@@ -7,7 +7,7 @@ class SpaceOutRanksForFavorites < ActiveRecord::Migration
 
   def change
     execute <<-SQL.squish
-      CREATE TEMPORARY VIEW fav_ranks (id, rank) AS
+      CREATE TEMPORARY TABLE fav_ranks (id, rank) AS
         SELECT id, ((row_number() OVER (
           PARTITION BY user_id, item_type
           ORDER BY fav_rank ASC,
@@ -21,6 +21,7 @@ class SpaceOutRanksForFavorites < ActiveRecord::Migration
           SELECT rank FROM fav_ranks WHERE fav_ranks.id = favorites.id
         )
       SQL
+    execute 'DROP TABLE fav_ranks'
     end
   end
 end

--- a/db/migrate/20170501234913_space_out_ranks_for_favorites.rb
+++ b/db/migrate/20170501234913_space_out_ranks_for_favorites.rb
@@ -15,6 +15,8 @@ class SpaceOutRanksForFavorites < ActiveRecord::Migration
         )) * 20) AS rank
         FROM favorites
     SQL
+    execute "CREATE INDEX ON fav_ranks (id)"
+    execute "VACUUM fav_ranks"
     say_with_time 'Updating rank column for favorites' do
       Favorite.all.update_in_batches(<<-SQL.squish)
         fav_rank = (


### PR DESCRIPTION
Should fix [one of our most frequent errors in Sentry](https://sentry.io/share/issue/3131393033362e323639393932333430/), which is triggered by a deadlock in Postgres.  Basically, if multiple reorder requests come in at roughly the same time, acts_as_list will try to renumber the list multiple times in parallel, resulting in a deadlock.

ranked-model solves this by spacing order numbers, so instead of 1, 2, 3, 4 it uses 10, 20, 30, 40.  This allows reordering to be completed in constant time: moving 3 (30) to the top of the list would be done by changing the position to 5, no shuffling required.