### PR TITLE
Fix media attribute plurals on related models

### DIFF
--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -59,7 +59,7 @@ class Anime < ApplicationRecord
   has_many :anime_productions, dependent: :destroy
   has_many :anime_characters, dependent: :destroy
   has_many :anime_staff, dependent: :destroy
-  has_many :media_attribute, through: :anime_media_attributes
+  has_many :media_attributes, through: :anime_media_attributes
   has_many :anime_media_attributes
   alias_attribute :show_type, :subtype
 

--- a/app/models/drama.rb
+++ b/app/models/drama.rb
@@ -50,7 +50,7 @@ class Drama < ApplicationRecord
   include Episodic
 
   enum subtype: %i[drama movie special]
-  has_many :media_attribute, through: :dramas_media_attributes
+  has_many :media_attributes, through: :dramas_media_attributes
   has_many :dramas_media_attributes
 
   has_attached_file :cover_image,

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -49,7 +49,7 @@ class Manga < ApplicationRecord
   has_many :chapters
   has_many :manga_characters, dependent: :destroy
   has_many :manga_staff, dependent: :destroy
-  has_many :media_attribute, through: :manga_media_attributes
+  has_many :media_attributes, through: :manga_media_attributes
   has_many :manga_media_attributes
 
   validates :chapter_count, numericality: { greater_than: 0 }, allow_nil: true


### PR DESCRIPTION
Need to use plurals for has_many through when trying to call `destroy!` on model, or will try to destroy on the other non thru through instead of the through table relation