### PR TITLE
adding custom enpoint to get issues for library entries for a user

### DIFF
--- a/app/controllers/library_entries_controller.rb
+++ b/app/controllers/library_entries_controller.rb
@@ -15,7 +15,7 @@ class LibraryEntriesController < ApplicationController
 
   def issues
     authenticate_user!
-    missing_library_engagement = {
+    missing_library_data = {
       rating_ids: [],
       reaction_ids: [],
       attributes_ids: []
@@ -27,12 +27,12 @@ class LibraryEntriesController < ApplicationController
     ).where(user: user)
 
     library_entries.each do |entry|
-      missing_library_engagement[:rating_ids] << entry.id if entry.rating.nil?
-      missing_library_engagement[:reaction_ids] << entry.id if entry.media_reaction.nil?
+      missing_library_data[:rating_ids] << entry.id if entry.rating.nil? && entry.status.completed?
+      missing_library_data[:reaction_ids] << entry.id if entry.media_reaction.nil?
       votes = entry.media.media_attribute_votes.select { |mv| mv.vote == :unvoted }
-      missing_library_engagement[:attributes_ids] << entry.id unless votes.empty?
+      missing_library_data[:attributes_ids] << entry.id unless votes.empty?
     end
-    render json: missing_library_engagement
+    render json: missing_library_data
   end
 
   def bulk_delete

--- a/app/controllers/library_entries_controller.rb
+++ b/app/controllers/library_entries_controller.rb
@@ -20,15 +20,15 @@ class LibraryEntriesController < ApplicationController
       reaction_ids: [],
       attributes_ids: []
     }
-    
+
     library_entries = LibraryEntry.includes(
-      :media_reaction, 
+      :media_reaction,
       media: :media_attribute_votes
     ).where(user: user)
 
     library_entries.each do |entry|
-      missing_library_engagement[:rating_ids] << entry.id if entry.rating == nil
-      missing_library_engagement[:reaction_ids] << entry.id if entry.media_reaction == nil
+      missing_library_engagement[:rating_ids] << entry.id if entry.rating.nil?
+      missing_library_engagement[:reaction_ids] << entry.id if entry.media_reaction.nil?
       votes = entry.media.media_attribute_votes.select { |mv| mv.vote == :unvoted }
       missing_library_engagement[:attributes_ids] << entry.id unless votes.empty?
     end

--- a/app/models/concerns/media.rb
+++ b/app/models/concerns/media.rb
@@ -52,6 +52,9 @@ module Media
     has_many :media_attributes,
       class_name: 'MediaAttribute',
       dependent: :destroy
+    has_many :media_attribute_votes,
+      class_name: 'MediaAttributeVote',
+      dependent: :destroy
     delegate :year, to: :start_date, allow_nil: true
 
     # finished: end date has passed

--- a/app/services/library_gaps_service.rb
+++ b/app/services/library_gaps_service.rb
@@ -9,6 +9,7 @@ class LibraryGapsService
         ON votes.media_id = library_entries.media_id
         AND votes.media_type = library_entries.media_type
         AND votes.user_id = library_entries.user_id
+        AND votes.vote <> 0
       LEFT OUTER JOIN media_reactions reacts
         ON reacts.library_entry_id = library_entries.id
     JOINS

--- a/app/services/library_gaps_service.rb
+++ b/app/services/library_gaps_service.rb
@@ -1,0 +1,33 @@
+class LibraryGapsService
+  def initialize(library_entries)
+    @entries = library_entries
+  end
+
+  def missing_engagement_ids
+    data = @entries.completed.joins(<<-JOINS.squish).group(<<-GROUP.squish).pluck(<<-PLUCK.squish)
+      LEFT OUTER JOIN media_attribute_votes votes
+        ON votes.media_id = library_entries.media_id
+        AND votes.media_type = library_entries.media_type
+        AND votes.user_id = library_entries.user_id
+      LEFT OUTER JOIN media_reactions reacts
+        ON reacts.library_entry_id = library_entries.id
+    JOINS
+      library_entries.id
+    GROUP
+      library_entries.id,
+      COUNT(votes.id),
+      COUNT(reacts.id),
+      COUNT(rating)
+    PLUCK
+
+    data.each_with_object(
+      attributes: [],
+      reaction: [],
+      rating: []
+    ) do |(id, votes, reactions, ratings), out|
+      out[:attributes] << id if votes.zero?
+      out[:reaction] << id if reactions.zero?
+      out[:rating] << id if ratings.zero?
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       jsonapi_resources :one_signal_players
 
       ### Library
+      get '/library-entries/_issues', to: 'library_entries#issues'
       delete '/library-entries/_bulk', to: 'library_entries#bulk_delete'
       patch '/library-entries/_bulk', to: 'library_entries#bulk_update'
       put '/library-entries/_bulk', to: 'library_entries#bulk_update'
@@ -166,7 +167,7 @@ end
 
 # == Route Map
 #
-# I, [2017-07-03T00:02:08.352974 #9]  INFO -- : Raven 2.4.0 configured not to capture errors: DSN not set
+# I, [2017-07-13T06:45:04.931696 #10565]  INFO -- : Raven 2.4.0 configured not to capture errors: DSN not set
 #                                                     Prefix Verb      URI Pattern                                                                                                Controller#Action
 #                                   user_relationships_waifu GET       /api/edge/users/:user_id/relationships/waifu(.:format)                                                     users#show_relationship {:relationship=>"waifu"}
 #                                                            PUT|PATCH /api/edge/users/:user_id/relationships/waifu(.:format)                                                     users#update_relationship {:relationship=>"waifu"}
@@ -395,6 +396,7 @@ end
 #                                                            PATCH     /api/edge/one-signal-players/:id(.:format)                                                                 one_signal_players#update
 #                                                            PUT       /api/edge/one-signal-players/:id(.:format)                                                                 one_signal_players#update
 #                                                            DELETE    /api/edge/one-signal-players/:id(.:format)                                                                 one_signal_players#destroy
+#                                    library_entries__issues GET       /api/edge/library-entries/_issues(.:format)                                                                library_entries#issues
 #                                      library_entries__bulk DELETE    /api/edge/library-entries/_bulk(.:format)                                                                  library_entries#bulk_delete
 #                                                            PATCH     /api/edge/library-entries/_bulk(.:format)                                                                  library_entries#bulk_update
 #                                                            PUT       /api/edge/library-entries/_bulk(.:format)                                                                  library_entries#bulk_update


### PR DESCRIPTION
Should be able to call it like this:

```
curl 'http://localhost:3000/api/edge/library-entries/_issues' -H 'Host: localhost:3000' -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7' -H 'Accept: application/vnd.api+json' -H 'Accept-Language: en-US,en;q=0.5' --compressed -H 'Authorization: Bearer 5e33becfa3c2ab149def9b05e01d1b007db35a0b60555547a27b968226e95efc'
```

and get back

```
{"rating_ids":[],"reaction_ids":[],"attributes_ids":[]}
```