### PR TITLE
Feature: Custom Profile URLs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -159,7 +159,7 @@ class User < ApplicationRecord
   has_many :one_signal_players, dependent: :destroy
   has_many :reposts, dependent: :destroy
   has_many :ip_addresses, dependent: :destroy, class_name: 'UserIpAddress'
-  validates :email, :name, :password, absence: true, if: :unregistered?
+  validates :email, :name, :password, :slug, absence: true, if: :unregistered?
   validates :email, :name, :password_digest, presence: true, if: :registered?
   validates :email, uniqueness: { case_sensitive: false },
                     if: ->(user) { user.registered? && user.email_changed? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -163,24 +163,23 @@ class User < ApplicationRecord
   validates :email, :name, :password_digest, presence: true, if: :registered?
   validates :email, uniqueness: { case_sensitive: false },
                     if: ->(user) { user.registered? && user.email_changed? }
-  validates :slug, uniqueness: { case_sensitive: false },
-                   format: {
-                     with: /\A[_A-Za-z0-9]+\z/,
-                     message: <<-EOF.squish
-                       can only contain letters, numbers, and underscores.
-                     EOF
-                   },
-                   if: :slug_changed?
-  validates :slug, format: {
-    with: /\A[A-Za-z0-9]/,
-    message: 'must begin with a letter or number'
-  }, if: :slug_changed?
-  validates :slug, format: {
-    without: /\A[0-9]*\z/,
-    message: 'cannot be entirely numbers'
-  }, if: :slug_changed?
-  validates :slug, length: 3..20, allow_nil: true, if: :slug_changed?
-  validate :not_reserved_slug, if: :registered?
+  with_options if: :slug_changed?, allow_nil: true do
+    validates :slug, uniqueness: { case_sensitive: false }
+    validates :slug, format: {
+      with: /\A[_A-Za-z0-9]+\z/,
+      message: 'can only contain letters, numbers, and underscores'
+    }
+    validates :slug, format: {
+      with: /\A[A-Za-z0-9]/,
+      message: 'must begin with a letter or number'
+    }
+    validates :slug, format: {
+      without: /\A[0-9]*\z/,
+      message: 'cannot be entirely numbers'
+    }
+    validates :slug, length: 3..20
+  end
+  validate :not_reserved_slug, if: ->(user) { user.slug.present? && user.slug_changed? }
   validates :name, presence: true,
                    length: { minimum: 3, maximum: 20 },
                    if: ->(user) { user.registered? && user.name_changed? }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -193,6 +193,9 @@ class User < ApplicationRecord
   scope :by_name, ->(*names) {
     where('lower(users.name) IN (?)', names.flatten.map(&:downcase))
   }
+  scope :by_email, ->(*emails) {
+    where('lower(users.email) IN (?)', emails.flatten.map(&:downcase))
+  }
   scope :blocking, ->(*users) { where.not(id: users.flatten) }
   scope :followed_first, ->(user) {
     user_id = sanitize(user.id)
@@ -203,10 +206,8 @@ class User < ApplicationRecord
     SQL
   }
 
-  # TODO: I think Devise can handle this for us
   def self.find_for_auth(identification)
-    identification = [identification.downcase]
-    where('lower(email)=? OR lower(name)=?', *(identification * 2)).first
+    by_email(identification).first
   end
 
   def not_reserved_slug

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -313,6 +313,9 @@ class User < ApplicationRecord
     update_profile_completed.save!
   end
 
+  # TODO: remove once slugs are live on frontend
+  before_validation(if: :name_changed?) { self.slug = name }
+
   before_destroy do
     # Destroy personal posts
     posts.where(target_group: nil, target_user: nil, media: nil).destroy_all

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
-#  slug                        :citext
+#  slug                        :citext           indexed
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null
@@ -84,6 +84,7 @@
 #
 #  index_users_on_email        (email) UNIQUE
 #  index_users_on_facebook_id  (facebook_id) UNIQUE
+#  index_users_on_slug         (slug) UNIQUE
 #  index_users_on_to_follow    (to_follow)
 #  index_users_on_waifu_id     (waifu_id)
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -105,7 +105,7 @@ class User < ApplicationRecord
     feature featured features feed follow followers following hummingbird index
     javascript json kitsu sysadmin sysadministrator system unfollow user users
     wiki you staff mod
-  ].freeze
+  ].to_set.freeze
 
   enum rating_system: %i[simple advanced regular]
   rolify after_add: :update_title, after_remove: :update_title

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
+#  slug                        :citext
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null
@@ -161,6 +162,7 @@ class User < ApplicationRecord
   validates :email, :name, :password_digest, presence: true, if: :registered?
   validates :email, uniqueness: { case_sensitive: false },
                     if: ->(user) { user.registered? && user.email_changed? }
+  validates :slug, uniqueness: { case_sensitive: false }, if: :slug_changed?
   validates :name, uniqueness: { case_sensitive: false },
                    length: { minimum: 3, maximum: 20 },
                    if: ->(user) { user.registered? && user.name_changed? },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -179,6 +179,7 @@ class User < ApplicationRecord
     without: /\A[0-9]*\z/,
     message: 'cannot be entirely numbers'
   }, if: :slug_changed?
+  validates :slug, length: 3..20, allow_nil: true, if: :slug_changed?
   validate :not_reserved_slug, if: :registered?
   validates :name, presence: true,
                    length: { minimum: 3, maximum: 20 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -316,7 +316,10 @@ class User < ApplicationRecord
   end
 
   # TODO: remove once slugs are live on frontend
-  before_validation(if: :name_changed?) { self.slug = name }
+  before_validation(if: :name_changed?) do
+    # Don't override slug if the slug has already been changed
+    self.slug = name unless slug_changed?
+  end
 
   before_destroy do
     # Destroy personal posts

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -43,6 +43,7 @@ class UserResource < BaseResource
     @model.destroy_later
   end
 
+  filter :slug
   filter :name, apply: ->(records, value, _o) { records.by_name(value.first) }
   filter :self, apply: ->(records, _v, options) {
     current_user = options[:context][:current_user]&.resource_owner

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -1,13 +1,12 @@
 class UserResource < BaseResource
   PRIVATE_FIELDS = %i[email password confirmed previous_email language time_zone country
                       share_to_global title_language_preference sfw_filter rating_system
-                      theme].freeze
+                      theme facebook_id].freeze
 
-  attributes :name, :past_names, :slug, :about, :about_formatted, :location, :waifu_or_husbando,
-    :followers_count, :facebook_id, :following_count, :life_spent_on_anime, :birthday, :gender,
-    :comments_count, :favorites_count, :likes_given_count, :reviews_count, :likes_received_count,
-    :posts_count, :ratings_count, :media_reactions_count, :pro_expires_at, :title,
-    :profile_completed, :feed_completed, :website, :slug
+  attributes :name, :past_names, :slug, :about, :location, :waifu_or_husbando, :followers_count,
+    :following_count, :life_spent_on_anime, :birthday, :gender, :comments_count, :favorites_count,
+    :likes_given_count, :reviews_count, :likes_received_count, :posts_count, :ratings_count,
+    :media_reactions_count, :pro_expires_at, :title, :profile_completed, :feed_completed, :website
   attributes :avatar, :cover_image, format: :attachment
   attributes(*PRIVATE_FIELDS)
 

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -1,14 +1,13 @@
 class UserResource < BaseResource
-  PRIVATE_FIELDS = %i[email password confirmed previous_email language time_zone
-                      country share_to_global title_language_preference
-                      sfw_filter rating_system theme].freeze
+  PRIVATE_FIELDS = %i[email password confirmed previous_email language time_zone country
+                      share_to_global title_language_preference sfw_filter rating_system
+                      theme].freeze
 
-  attributes :name, :past_names, :about, :bio, :about_formatted, :location,
-    :waifu_or_husbando, :followers_count, :facebook_id, :following_count,
-    :life_spent_on_anime, :birthday, :gender, :comments_count, :favorites_count,
-    :likes_given_count, :reviews_count, :likes_received_count, :posts_count,
-    :ratings_count, :media_reactions_count, :pro_expires_at, :title,
-    :profile_completed, :feed_completed, :website
+  attributes :name, :past_names, :slug, :about, :about_formatted, :location, :waifu_or_husbando,
+    :followers_count, :facebook_id, :following_count, :life_spent_on_anime, :birthday, :gender,
+    :comments_count, :favorites_count, :likes_given_count, :reviews_count, :likes_received_count,
+    :posts_count, :ratings_count, :media_reactions_count, :pro_expires_at, :title,
+    :profile_completed, :feed_completed, :website, :slug
   attributes :avatar, :cover_image, format: :attachment
   attributes(*PRIVATE_FIELDS)
 

--- a/db/migrate/20170819034722_add_slug_to_users.rb
+++ b/db/migrate/20170819034722_add_slug_to_users.rb
@@ -1,0 +1,6 @@
+class AddSlugToUsers < ActiveRecord::Migration
+  def change
+    enable_extension 'citext'
+    add_column :users, :slug, :citext
+  end
+end

--- a/db/migrate/20170819034850_fill_slug_on_users.rb
+++ b/db/migrate/20170819034850_fill_slug_on_users.rb
@@ -1,0 +1,12 @@
+require 'update_in_batches'
+
+class FillSlugOnUsers < ActiveRecord::Migration
+  using UpdateInBatches
+  disable_ddl_transaction!
+
+  def change
+    say_with_time 'Filling slugs for staff' do
+      User.where(title: %w[Staff Mod]).update_in_batches('slug = name')
+    end
+  end
+end

--- a/db/migrate/20170819034850_fill_slug_on_users.rb
+++ b/db/migrate/20170819034850_fill_slug_on_users.rb
@@ -5,8 +5,8 @@ class FillSlugOnUsers < ActiveRecord::Migration
   disable_ddl_transaction!
 
   def change
-    say_with_time 'Filling slugs for staff' do
-      User.where(title: %w[Staff Mod]).update_in_batches('slug = name')
+    say_with_time 'Filling slugs' do
+      User.all.update_in_batches('slug = name')
     end
   end
 end

--- a/db/migrate/20170819055109_add_uniqueness_constraint_to_user_slugs.rb
+++ b/db/migrate/20170819055109_add_uniqueness_constraint_to_user_slugs.rb
@@ -1,0 +1,5 @@
+class AddUniquenessConstraintToUserSlugs < ActiveRecord::Migration
+  def change
+    add_index :users, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20170919034156) do
   enable_extension "hstore"
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
+  enable_extension "citext"
 
   create_table "ama_subscribers", force: :cascade do |t|
     t.integer  "ama_id",     null: false
@@ -1504,6 +1505,7 @@ ActiveRecord::Schema.define(version: 20170919034156) do
     t.datetime "deleted_at"
     t.integer  "media_reactions_count",                   default: 0,           null: false
     t.integer  "status",                                  default: 1,           null: false
+    t.citext   "slug"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1510,6 +1510,7 @@ ActiveRecord::Schema.define(version: 20170919034156) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["facebook_id"], name: "index_users_on_facebook_id", unique: true, using: :btree
+  add_index "users", ["slug"], name: "index_users_on_slug", unique: true, using: :btree
   add_index "users", ["to_follow"], name: "index_users_on_to_follow", using: :btree
   add_index "users", ["waifu_id"], name: "index_users_on_waifu_id", using: :btree
 

--- a/spec/api/oauth_spec.rb
+++ b/spec/api/oauth_spec.rb
@@ -20,12 +20,6 @@ RSpec.describe 'OAuth2', type: :request do
       }.not_to raise_error
     end
 
-    it 'should work if given the username and right password' do
-      expect {
-        client.password.get_token(user.name, user.password)
-      }.not_to raise_error
-    end
-
     it 'should not work if given the wrong password' do
       expect {
         client.password.get_token(user.email, '123')

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -63,6 +63,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
+#  slug                        :citext
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -63,7 +63,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
-#  slug                        :citext
+#  slug                        :citext           indexed
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null
@@ -85,6 +85,7 @@
 #
 #  index_users_on_email        (email) UNIQUE
 #  index_users_on_facebook_id  (facebook_id) UNIQUE
+#  index_users_on_slug         (slug) UNIQUE
 #  index_users_on_to_follow    (to_follow)
 #  index_users_on_waifu_id     (waifu_id)
 #

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe UsersController, type: :controller do
         type: 'users',
         attributes: {
           name: 'Senjougahara',
-          bio: 'hitagi crab',
+          about: 'hitagi crab',
           email: 'senjougahara@hita.gi',
           password: 'headtilt'
         }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -62,7 +62,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
-#  slug                        :citext
+#  slug                        :citext           indexed
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null
@@ -84,6 +84,7 @@
 #
 #  index_users_on_email        (email) UNIQUE
 #  index_users_on_facebook_id  (facebook_id) UNIQUE
+#  index_users_on_slug         (slug) UNIQUE
 #  index_users_on_to_follow    (to_follow)
 #  index_users_on_waifu_id     (waifu_id)
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -62,6 +62,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
+#  slug                        :citext
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,7 +62,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
-#  slug                        :citext
+#  slug                        :citext           indexed
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null
@@ -84,6 +84,7 @@
 #
 #  index_users_on_email        (email) UNIQUE
 #  index_users_on_facebook_id  (facebook_id) UNIQUE
+#  index_users_on_slug         (slug) UNIQUE
 #  index_users_on_to_follow    (to_follow)
 #  index_users_on_waifu_id     (waifu_id)
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -137,17 +137,13 @@ RSpec.describe User, type: :model do
     end
   end
 
-  it 'should reserve certain names case-insensitively' do
+  it 'should reserve certain slugs case-insensitively' do
     user = User.new(slug: 'admin')
     expect(user).to be_invalid
     expect(user.errors[:slug]).not_to be_empty
   end
 
   describe 'find_for_auth' do
-    it 'should be able to query by username' do
-      u = User.find_for_auth(persisted_user.name)
-      expect(u).to eq(persisted_user)
-    end
     it 'should be able to query by email' do
       u = User.find_for_auth(persisted_user.email)
       expect(u).to eq(persisted_user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe User, type: :model do
   it { should belong_to(:pro_membership_plan) }
   it { should have_many(:followers).dependent(:destroy) }
   it { should have_many(:following).dependent(:destroy) }
-  it { should validate_uniqueness_of(:slug).case_insensitive }
+  it { should validate_uniqueness_of(:slug).case_insensitive.allow_nil }
   it { should validate_uniqueness_of(:email).case_insensitive }
   it { should have_many(:library_events).dependent(:destroy) }
   it { should have_many(:notification_settings).dependent(:destroy) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,6 +62,7 @@
 #  sfw_filter                  :boolean          default(TRUE)
 #  share_to_global             :boolean          default(TRUE), not null
 #  sign_in_count               :integer          default(0)
+#  slug                        :citext
 #  stripe_token                :string(255)
 #  subscribed_to_newsletter    :boolean          default(TRUE)
 #  theme                       :integer          default(0), not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe User, type: :model do
   it { should belong_to(:pro_membership_plan) }
   it { should have_many(:followers).dependent(:destroy) }
   it { should have_many(:following).dependent(:destroy) }
-  it { should validate_uniqueness_of(:name).case_insensitive }
+  it { should validate_uniqueness_of(:slug).case_insensitive }
   it { should validate_uniqueness_of(:email).case_insensitive }
   it { should have_many(:library_events).dependent(:destroy) }
   it { should have_many(:notification_settings).dependent(:destroy) }
@@ -138,9 +138,9 @@ RSpec.describe User, type: :model do
   end
 
   it 'should reserve certain names case-insensitively' do
-    user = User.new(name: 'admin')
+    user = User.new(slug: 'admin')
     expect(user).to be_invalid
-    expect(user.errors[:name]).not_to be_empty
+    expect(user.errors[:slug]).not_to be_empty
   end
 
   describe 'find_for_auth' do


### PR DESCRIPTION
# Goal

Loosen up username requirements by separating the URL from the username.

# How it works

Introduces a new `slug` column representing the user's choice of URL.

Once again, stealing Facebook's behavior here.  So by default, users are at `/users/5554` (their ID number) but they can choose a Custom URL such as `nuck` and get `/users/nuck`.

I pulled in the `citext` (case-insensitive text) Postgres extension because it'll make our life easier on this.  I checked, and RDS supports it, so we're good 👌 The only downside to `citext` is that it interferes with index usage during `LIKE` queries, but we don't use `LIKE` queries for this so... who cares?

# Eventually Needed on Frontend
This should be deployable as-is, but will need the following frontend changes to actually expose it:

* Switch to `filter[slug]=nuck` instead of `filter[name]=nuck`
* Stop redirecting `/users/5554` to `/users/name` if the user doesn't have a slug
* Provide an interface to pick your slug

Once these changes are made, we can loosen the requirements for the `name` column and ship this fully