### PR TITLE
Only import existing entries, and prefer kitsu attributes

### DIFF
--- a/app/services/list_sync/my_anime_list.rb
+++ b/app/services/list_sync/my_anime_list.rb
@@ -28,7 +28,7 @@ module ListSync
         import = ListImport::MyAnimeListXML.new(
           input_file: their_xml_for(kind),
           user: linked_account.user,
-          strategy: :greater,
+          strategy: :merge,
           status: :running
         )
         import.save!


### PR DESCRIPTION
Added a new `merge` strategy to use for initial sync of mal export. This only tries to import data for entries that already exist on kitsu, and will only assign attributes that haven't already been set on kitsu entries. So, your existing kitsu ratings will remain unchanged, but if you don't have any notes, your tags and comments from mal will be added to the entry. That way they aren't deleted from mal during initial sync.