### PR TITLE
Refactor NotificationSetting.setup_notification_settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'rails', '4.2.8'
 gem 'rails-api'
 
 # Database Stuff
+gem 'activerecord-import' # Run bulk imports quicker
 gem 'algoliasearch-rails' # Future Search
 gem 'attr_encrypted', '~>3.0.0' # encrypt linked_profile tokens
 gem 'chewy' # ElasticSearch (TODO: remove this once we switch to Algolia)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       activemodel (= 4.2.8)
       activesupport (= 4.2.8)
       arel (~> 6.0)
+    activerecord-import (0.20.1)
+      activerecord (>= 3.2)
     activesupport (4.2.8)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -563,6 +565,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   addressable
   algoliasearch-rails
   annotate

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -48,7 +48,7 @@ class NotificationSetting < ApplicationRecord
     end
   end
 
-  def self.setup_notification_settings(user)
+  def self.setup!(user)
     # Get the list of existing settings
     existing_settings = setting_types.values_at(*where(user: user).pluck(:setting_type))
     # Figure out which ones to create

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -25,6 +25,16 @@
 
 class NotificationSetting < ApplicationRecord
   NOTIFICATION_TYPES = %i[mentions replies likes follows posts reaction_votes].freeze
+  DEFAULT_SETTINGS = {
+    #                FB,   Mobile, Email, Web
+    mentions:       [false, false, false, true],
+    replies:        [false, false, false, true],
+    likes:          [false, false, false, true],
+    follows:        [false, false, false, true],
+    posts:          [false, false, false, true],
+    reaction_votes: [false, false, false, true]
+  }.freeze
+
   enum setting_type: NOTIFICATION_TYPES
   belongs_to :user
 
@@ -39,14 +49,16 @@ class NotificationSetting < ApplicationRecord
   end
 
   def self.setup_notification_settings(user)
-    NOTIFICATION_TYPES.each do |st|
-      NotificationSetting.where(
-        setting_type: st,
-        user: user,
-        fb_messenger_enabled: false,
-        mobile_enabled: false,
-        email_enabled: false
-      ).first_or_create
-    end
+    # Get the list of existing settings
+    existing_settings = setting_types.values_at(*where(user: user).pluck(:setting_type))
+    # Figure out which ones to create
+    settings_to_create = (NOTIFICATION_TYPES - existing_settings)
+    # Build a list of values to insert
+    settings = DEFAULT_SETTINGS.select { |k, _| settings_to_create.include?(k) }
+                               .map { |key, values| [user.id, setting_types[key], *values] }
+    # Import 'em
+    NotificationSetting.import(%i[
+      user_id setting_type fb_messenger_enabled mobile_enabled email_enabled web_enabled
+    ], settings)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -366,7 +366,7 @@ class User < ApplicationRecord
 
   after_create do
     # Set up Notification Settings for User
-    NotificationSetting.setup_notification_settings(self)
+    NotificationSetting.setup!(self)
   end
 
   before_update do


### PR DESCRIPTION
Using `activerecord-import` (to be used elsewhere too!) to add them all in one fell swoop, making it faster when we (1) create new users (2) add new notification settings to default for users

Also makes it easy to adjust the defaults!