### PR TITLE
Simplify sidekiq queue structure

### DIFF
--- a/app/workers/activity_deletion_worker.rb
+++ b/app/workers/activity_deletion_worker.rb
@@ -1,5 +1,6 @@
 class ActivityDeletionWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'now'
 
   # activities is a structure of [[['user', '5554'], { foreign_id: 'repost:1234' }], ...]
   def perform(activities)

--- a/app/workers/ama_starting_worker.rb
+++ b/app/workers/ama_starting_worker.rb
@@ -1,5 +1,6 @@
 class AMAStartingWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'soon'
 
   def perform(ama)
     ama.send_ama_notification

--- a/app/workers/average_rating_update_worker.rb
+++ b/app/workers/average_rating_update_worker.rb
@@ -2,7 +2,7 @@ class AverageRatingUpdateWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'later'
 
-  def perform
-    [Anime, Manga, Drama].each(&:update_average_ratings)
+  def perform(klass_name)
+    klass_name.constantize.update_average_ratings
   end
 end

--- a/app/workers/average_rating_update_worker.rb
+++ b/app/workers/average_rating_update_worker.rb
@@ -1,5 +1,6 @@
 class AverageRatingUpdateWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'later'
 
   def perform
     [Anime, Manga, Drama].each(&:update_average_ratings)

--- a/app/workers/community_recommendation_reason_worker.rb
+++ b/app/workers/community_recommendation_reason_worker.rb
@@ -1,5 +1,6 @@
 class CommunityRecommendationReasonWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'soon'
 
   def perform(post, community_recommendation)
     community_recommendation.send_community_recommendation(post)

--- a/app/workers/counter_cache_reset_worker.rb
+++ b/app/workers/counter_cache_reset_worker.rb
@@ -2,6 +2,7 @@ require_dependency 'counter_cache_resets'
 
 class CounterCacheResetWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'later'
 
   def perform
     CounterCacheResets.media_user_counts

--- a/app/workers/data_import_worker.rb
+++ b/app/workers/data_import_worker.rb
@@ -1,5 +1,6 @@
 class DataImportWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'eventually'
 
   def perform(type, klass, id, opts = {})
     importer = klass.new(opts)

--- a/app/workers/destruction_worker.rb
+++ b/app/workers/destruction_worker.rb
@@ -1,5 +1,6 @@
 class DestructionWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'soon'
 
   def perform(klass, id)
     klass.constantize.unscoped.find(id).destroy

--- a/app/workers/group_unread_fanout_worker.rb
+++ b/app/workers/group_unread_fanout_worker.rb
@@ -1,5 +1,6 @@
 class GroupUnreadFanoutWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'soon'
 
   def perform(group_id, source_user_id = nil)
     group = Group.find(group_id)

--- a/app/workers/library_entry_log_removal_worker.rb
+++ b/app/workers/library_entry_log_removal_worker.rb
@@ -1,5 +1,6 @@
 class LibraryEntryLogRemovalWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'later'
 
   def perform
     LibraryEntryLog.where('created_at <= ?', 1.month.ago).destroy_all

--- a/app/workers/list_import_worker.rb
+++ b/app/workers/list_import_worker.rb
@@ -1,5 +1,6 @@
 class ListImportWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'now'
 
   def perform(import_id)
     import = ListImport.find_by(id: import_id)

--- a/app/workers/list_sync/destroy_worker.rb
+++ b/app/workers/list_sync/destroy_worker.rb
@@ -2,7 +2,7 @@ module ListSync
   class DestroyWorker
     include Sidekiq::Worker
     include ListSync::ErrorHandling
-    sidekiq_options retry: 3, queue: 'sync'
+    sidekiq_options retry: 3, queue: 'soon'
 
     def perform(linked_account_id, media_type, media_id)
       linked_account = LinkedAccount.find(linked_account_id)

--- a/app/workers/list_sync/sync_worker.rb
+++ b/app/workers/list_sync/sync_worker.rb
@@ -2,7 +2,7 @@ module ListSync
   class SyncWorker
     include Sidekiq::Worker
     include ListSync::ErrorHandling
-    sidekiq_options retry: false, queue: 'sync'
+    sidekiq_options retry: false, queue: 'soon'
 
     def perform(linked_account_id, user_id)
       user = User.find(user_id)

--- a/app/workers/list_sync/update_worker.rb
+++ b/app/workers/list_sync/update_worker.rb
@@ -2,7 +2,7 @@ module ListSync
   class UpdateWorker
     include Sidekiq::Worker
     include ListSync::ErrorHandling
-    sidekiq_options retry: 3, queue: 'sync'
+    sidekiq_options retry: 3, queue: 'soon'
 
     def perform(linked_account_id, library_entry_id)
       linked_account = LinkedAccount.find(linked_account_id)

--- a/app/workers/media_follow_update_worker.rb
+++ b/app/workers/media_follow_update_worker.rb
@@ -1,6 +1,6 @@
 class MediaFollowUpdateWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 6
+  sidekiq_options retry: 6, queue: 'soon'
 
   def perform(user_id, media_type, media_id, action, progress_was = nil, progress = nil) # rubocop:disable Metrics/ParameterLists
     user = User.find(user_id)

--- a/app/workers/one_signal_notification_worker.rb
+++ b/app/workers/one_signal_notification_worker.rb
@@ -1,6 +1,6 @@
 class OneSignalNotificationWorker
   include Sidekiq::Worker
-  sidekiq_options queue: 'notifications'
+  sidekiq_options queue: 'soon'
 
   def perform(notification)
     service = GetstreamWebhookService.new(notification)

--- a/app/workers/ranking_update_worker.rb
+++ b/app/workers/ranking_update_worker.rb
@@ -1,5 +1,6 @@
 class RankingUpdateWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'later'
 
   def perform
     [Anime, Manga, Drama].each(&:update_rankings)

--- a/app/workers/trending_fanout_worker.rb
+++ b/app/workers/trending_fanout_worker.rb
@@ -1,5 +1,7 @@
 class TrendingFanoutWorker
   include Sidekiq::Worker
+  # Since we don't currently display network trending on site, this is a very low priority.
+  sidekiq_options queue: 'eventually'
 
   def perform(namespace, half_life, user, id, weight)
     user = User.find(user)

--- a/app/workers/update_rating_frequency_worker.rb
+++ b/app/workers/update_rating_frequency_worker.rb
@@ -1,5 +1,6 @@
 class UpdateRatingFrequencyWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'soon'
 
   def perform(klass_name, klass_id, rating, diff)
     update_query = <<-EOF

--- a/app/workers/upload_removal_worker.rb
+++ b/app/workers/upload_removal_worker.rb
@@ -1,5 +1,6 @@
 class UploadRemovalWorker
   include Sidekiq::Worker
+  sidekiq_options queue: 'later'
 
   def perform
     Upload.orphan.destroy_all

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,7 +71,6 @@ module Kitsu
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true
-    config.action_mailer.deliver_later_queue_name = :soon
     config.action_mailer.smtp_settings = {
       address: ENV['SMTP_ADDRESS'],
       port: ENV['SMTP_PORT']&.to_i,

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,6 +71,7 @@ module Kitsu
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.perform_deliveries = true
     config.action_mailer.raise_delivery_errors = true
+    config.action_mailer.deliver_later_queue_name = :soon
     config.action_mailer.smtp_settings = {
       address: ENV['SMTP_ADDRESS'],
       port: ENV['SMTP_PORT']&.to_i,
@@ -84,6 +85,7 @@ module Kitsu
 
     # Set ActiveJob adapter
     config.active_job.queue_adapter = :sidekiq
+    config.active_job.default_queue_name = :later
 
     # Configure Scaffold Generators
     config.generators do |g|

--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -1,0 +1,4 @@
+# RAILS-5: replace with config.action_mailer.deliver_later_queue_name
+ActionMailer::DeliveryJob.class_eval do
+  queue_as :soon
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,10 +3,10 @@
 production:
   :concurrency: 40
 :queues:
-  - [now, 5]
-  - [soon, 4]
-  - [later, 2]
-  - [eventually, 1]
+  - [now, 5] # Within a few seconds
+  - [soon, 4] # Within a few minutes
+  - [later, 2] # Within an hour
+  - [eventually, 1] # Within a few hours
 :schedule:
   # Cron is *pattern matching times*, with the following format:
   #  - fields: seconds minutes hours date month weekday

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,18 +8,35 @@ production:
   - [later, 2]
   - [eventually, 1]
 :schedule:
+  # Cron is *pattern matching times*, with the following format:
+  #  - fields: seconds minutes hours date month weekday
+  #  - a,b,c means "whenever this field equals a or b or c"
+  #  - */15 means "whenever it's divisible by 15"
+  #  - hour is 0..23
+  #  - weekday is 0..6
+  #  - date is 1..31
+  #  - month is 1..12
+  #
+  # Alternatively you can use "every: 6h" but that apparently runs it once on each worker server
+  anime_rating_update:
+    class: AverageRatingUpdateWorker
+    args: Anime
+    # Every 6 hours
+    cron: '0 0 */6 * * *'
+  manga_rating_update:
+    class: AverageRatingUpdateWorker
+    args: Manga
+    # Every 6 hours
+    cron: '0 0 */6 * * *'
   CounterCacheResetWorker:
-    every: 12h
-    queue: later
-  AverageRatingUpdateWorker:
-    every: 6h
-    queue: soon
+    # Once a day
+    cron: '0 0 0 * * *'
   RankingUpdateWorker:
-    every: 12h
-    queue: later
+    # Every 6 hours, 5 minutes into the hour (so ratings get updated first)
+    cron: '0 5 */6 * * *'
   LibraryEntryLogRemovalWorker:
-    every: 24h
-    queue: eventually
+    # Once a day
+    cron: '0 0 0 * * *'
   UploadRemovalWorker:
-    every: 12h
-    queue: later
+    # Twice a day
+    cron: '0 0 */12 * * *'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,11 +3,10 @@
 production:
   :concurrency: 40
 :queues:
-  - [default, 3]
-  - [mailers, 2]
-  - [paperclip, 2]
-  - [notifications, 3]
-  - [chewy, 1]
+  - [now, 5]
+  - [soon, 4]
+  - [later, 2]
+  - [eventually, 1]
 :schedule:
   CounterCacheResetWorker:
     every: 12h

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,11 +10,16 @@ production:
 :schedule:
   CounterCacheResetWorker:
     every: 12h
+    queue: later
   AverageRatingUpdateWorker:
     every: 6h
+    queue: soon
   RankingUpdateWorker:
     every: 12h
+    queue: later
   LibraryEntryLogRemovalWorker:
-    every: 12h
+    every: 24h
+    queue: eventually
   UploadRemovalWorker:
     every: 12h
+    queue: later


### PR DESCRIPTION
This PR does three things:

* Simplifies to four priority-based queues
* Changes our scheduled tasks to use cron-style declarations
* Splits average rating update into separate Anime and Manga tasks for Parallelism™

# New Queues
 - `now` — run within a few seconds (metrics alert @ 30 seconds)
 - `soon` — run within a few minutes (metrics alert @ 10 minutes)
 - `later` — run within an hour (metrics alert @ 2 hours)
 - `eventually` — run within a few hours (metrics alert @ 6 hours)

# Cron Declarations
I happened to catch this [in the sidekiq-scheduler readme](https://github.com/Moove-it/sidekiq-scheduler#notes-about-running-on-multiple-hosts):

>`cron` and `at` jobs are pushed once regardless of the number of sidekiq-scheduler running instances, assumming that time deltas between hosts is less than 24 hours.
>
>`every`, `interval` and `in` jobs will be pushed once per host.

We've been using `every` for our declarations, but we have two sidekiq hosts currently and may need to add more soon.  We've probably been running these tasks twice without even realizing it, so I switched to `cron` to fix that.

It's not pretty, but I put some docs for how to read a cron declaration, and comments on each declaration to explain it.

# Separate Average Rating Jobs
I split the average rating updates into two separate scheduled tasks so that they can run In Parallel™