### PR TITLE
Reset Postgres sequences nightly

### DIFF
--- a/app/workers/postgres_sequence_worker.rb
+++ b/app/workers/postgres_sequence_worker.rb
@@ -1,0 +1,10 @@
+require_dependency 'postgres_sequence_fixer'
+
+class PostgresSequenceWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'eventually'
+
+  def perform
+    PostgresSequenceFixer.run
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -51,3 +51,6 @@ production:
   HuluMappingWorker:
     # Once a day
     cron: '0 0 0 * * *'
+  PostgresSequenceWorker:
+    # Once a day
+    cron: '0 0 0 * * *'

--- a/lib/postgres_sequence_fixer.rb
+++ b/lib/postgres_sequence_fixer.rb
@@ -1,0 +1,52 @@
+class PostgresSequenceFixer
+  def self.run
+    sequences.each { |s| new(s).run }
+  end
+
+  def self.sequences
+    execute(<<-SQL).values.flatten
+      SELECT relname
+      FROM pg_class
+      WHERE relkind = 'S'
+    SQL
+  end
+
+  def initialize(sequence_name)
+    @sequence_name = sequence_name
+  end
+
+  def run
+    execute(<<-SQL)
+      SELECT SETVAL(
+        '#{info[:sequence]}',
+        COALESCE(MAX(#{info[:column]}), 1)
+      )
+      FROM #{info[:table]}
+    SQL
+  end
+
+  def info
+    execute(<<-SQL).first.symbolize_keys
+      SELECT
+        S.relname AS sequence,
+        C.attname AS column,
+        T.relname AS table
+      FROM
+        pg_class AS S,
+        pg_depend AS D,
+        pg_class AS T,
+        pg_attribute AS C
+      WHERE S.relkind = 'S'
+        AND S.oid = D.objid
+        AND D.refobjid = T.oid
+        AND D.refobjid = C.attrelid
+        AND D.refobjsubid = C.attnum
+        AND S.relname = '#{@sequence_name}'
+    SQL
+  end
+
+  def self.execute(sql)
+    ApplicationRecord.connection.execute(sql.squish)
+  end
+  delegate :execute, to: :class
+end


### PR DESCRIPTION
Really simple thing to automatically reset postgres sequences nightly (adapted from [the postgres wiki](https://wiki.postgresql.org/wiki/Fixing_Sequences)) so mods don't have to keep picking random numbers for media IDs