### PR TITLE
Rails Admin: Exclude videos from streamer model

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -222,4 +222,10 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
       filterable true
     end
   end
+
+  config.model 'Streamer' do
+    fields :id, :site_name
+    include_all_fields
+    exclude_fields :videos
+  end
 end


### PR DESCRIPTION
I think this should fix the 502 error when trying to access `/admin/streamer`