### PR TITLE
Add BufferedStreamClient

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < JSONAPI::ResourceController
   end
 
   before_action :validate_token!
-  before_action :tag_sentry_context
   around_action :store_user_on_thread
 
   force_ssl if Rails.env.production?
@@ -27,6 +26,8 @@ class ApplicationController < JSONAPI::ResourceController
         Raven.capture_exception(error, extra)
       end
     end
+
+    before_action :tag_sentry_context
 
     def tag_sentry_context
       user = current_user&.resource_owner

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,8 @@ class ApplicationController < JSONAPI::ResourceController
   end
 
   before_action :validate_token!
+  around_action :store_user_on_thread
+  before_action :tag_sentry_context
 
   force_ssl if Rails.env.production?
 
@@ -25,8 +27,6 @@ class ApplicationController < JSONAPI::ResourceController
         Raven.capture_exception(error, extra)
       end
     end
-
-    before_action :tag_sentry_context
 
     def tag_sentry_context
       user = current_user&.resource_owner

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,8 @@ class ApplicationController < JSONAPI::ResourceController
   end
 
   before_action :validate_token!
-  around_action :store_user_on_thread
   before_action :tag_sentry_context
+  around_action :store_user_on_thread
 
   force_ssl if Rails.env.production?
 

--- a/app/controllers/concerns/doorkeeper_helpers.rb
+++ b/app/controllers/concerns/doorkeeper_helpers.rb
@@ -1,10 +1,6 @@
 module DoorkeeperHelpers
   extend ActiveSupport::Concern
 
-  included do
-    around_action :store_user_on_thread
-  end
-
   def store_user_on_thread
     Thread.current[:current_user] = doorkeeper_token&.resource_owner
     begin

--- a/app/controllers/concerns/doorkeeper_helpers.rb
+++ b/app/controllers/concerns/doorkeeper_helpers.rb
@@ -2,15 +2,15 @@ module DoorkeeperHelpers
   extend ActiveSupport::Concern
 
   included do
-    around_action :store_token_on_thread
+    around_action :store_user_on_thread
   end
 
-  def store_token_on_thread
-    Thread.current[:doorkeeper_token] = doorkeeper_token
+  def store_user_on_thread
+    Thread.current[:current_user] = doorkeeper_token&.resource_owner
     begin
       yield
     ensure
-      Thread.current[:doorkeeper_token] = nil
+      Thread.current[:current_user] = nil
     end
   end
 

--- a/app/controllers/concerns/doorkeeper_helpers.rb
+++ b/app/controllers/concerns/doorkeeper_helpers.rb
@@ -1,6 +1,19 @@
 module DoorkeeperHelpers
   extend ActiveSupport::Concern
 
+  included do
+    around_action :store_token_on_thread
+  end
+
+  def store_token_on_thread
+    Thread.current[:doorkeeper_token] = doorkeeper_token
+    begin
+      yield
+    ensure
+      Thread.current[:doorkeeper_token] = nil
+    end
+  end
+
   def current_user
     doorkeeper_token
   end

--- a/app/models/feed/stream_feed.rb
+++ b/app/models/feed/stream_feed.rb
@@ -14,6 +14,14 @@ class Feed
       @owner_feed = owner_feed
     end
 
+    def client
+      if Flipper.enabled?(:stream_batching)
+        @buffered_client ||= BufferedStreamClient.new(super)
+      else
+        self.class.client
+      end
+    end
+
     def activities(*)
       ActivityList.new(self).with_type(aggregated? ? :aggregated : :flat)
     end

--- a/app/models/feed/stream_feed.rb
+++ b/app/models/feed/stream_feed.rb
@@ -15,7 +15,7 @@ class Feed
     end
 
     def client
-      if Flipper.enabled?(:stream_batching)
+      if Flipper[:stream_batching].enabled?(User.current)
         @buffered_client ||= BufferedStreamClient.new(super)
       else
         self.class.client

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -229,7 +229,7 @@ class User < ApplicationRecord
 
   # @return [User,nil] the current user as stored in the Thread-local variable
   def current
-    Thread.current[:doorkeeper_token]&.resource_owner
+    Thread.current[:current_user]
   end
 
   # Override the version provided by has_secure_password to accept the aozora password too

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,7 +228,7 @@ class User < ApplicationRecord
   alias_method :flipper_id, :id
 
   # @return [User,nil] the current user as stored in the Thread-local variable
-  def current
+  def self.current
     Thread.current[:current_user]
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -227,6 +227,11 @@ class User < ApplicationRecord
 
   alias_method :flipper_id, :id
 
+  # @return [User,nil] the current user as stored in the Thread-local variable
+  def current
+    Thread.current[:doorkeeper_token]&.resource_owner
+  end
+
   # Override the version provided by has_secure_password to accept the aozora password too
   # @param unencrypted_password [String] the unencrypted password to test
   def authenticate(unencrypted_password)

--- a/app/workers/buffered_stream_client/buffer_action_worker.rb
+++ b/app/workers/buffered_stream_client/buffer_action_worker.rb
@@ -1,0 +1,10 @@
+class BufferedStreamClient
+  class BufferActionWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: 'soon'
+
+    def perform(group, id, method, parameters)
+      StreamRails.client.feed(group, id).public_send(method, *parameters)
+    end
+  end
+end

--- a/app/workers/buffered_stream_client/buffer_flush_worker.rb
+++ b/app/workers/buffered_stream_client/buffer_flush_worker.rb
@@ -1,0 +1,12 @@
+class BufferedStreamClient
+  class BufferFlushWorker
+    include Sidekiq::Worker
+    sidekiq_options queue: 'soon'
+
+    def perform(klass_name, queue)
+      klass = klass_name.safe_constantize
+      buffer = klass.new(StreamRails.client, queue)
+      buffer.flush
+    end
+  end
+end

--- a/app/workers/media_follow_update_worker.rb
+++ b/app/workers/media_follow_update_worker.rb
@@ -11,6 +11,8 @@ class MediaFollowUpdateWorker
     media_follow.public_send(action, *[progress_was, progress].compact)
   rescue ActiveRecord::RecordNotFound => ex
     Raven.capture_exception(ex)
+  ensure
+    Thread.current[:current_user] = nil
   end
 
   def self.perform_for_entry(entry, action, progress_was = nil, progress = nil)

--- a/app/workers/media_follow_update_worker.rb
+++ b/app/workers/media_follow_update_worker.rb
@@ -4,6 +4,7 @@ class MediaFollowUpdateWorker
 
   def perform(user_id, media_type, media_id, action, progress_was = nil, progress = nil) # rubocop:disable Metrics/ParameterLists
     user = User.find(user_id)
+    Thread.current[:current_user] = user
     media_class = media_type.safe_constantize
     media = media_class.find(media_id)
     media_follow = MediaFollowService.new(user, media)

--- a/app/workers/media_follow_update_worker.rb
+++ b/app/workers/media_follow_update_worker.rb
@@ -4,15 +4,12 @@ class MediaFollowUpdateWorker
 
   def perform(user_id, media_type, media_id, action, progress_was = nil, progress = nil) # rubocop:disable Metrics/ParameterLists
     user = User.find(user_id)
-    Thread.current[:current_user] = user
     media_class = media_type.safe_constantize
     media = media_class.find(media_id)
     media_follow = MediaFollowService.new(user, media)
     media_follow.public_send(action, *[progress_was, progress].compact)
   rescue ActiveRecord::RecordNotFound => ex
     Raven.capture_exception(ex)
-  ensure
-    Thread.current[:current_user] = nil
   end
 
   def self.perform_for_entry(entry, action, progress_was = nil, progress = nil)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,7 @@
 require 'sidekiq/middleware/server/chewy'
 require 'sidekiq/middleware/server/librato_metrics'
+require 'sidekiq/middleware/server/current_user'
+require 'sidekiq/middleware/client/current_user'
 
 Sidekiq.default_worker_options = { queue: 'later' }
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,11 +7,19 @@ Sidekiq.configure_server do |config|
   config.redis = { url: ENV['REDIS_URL'] }
   config.server_middleware do |chain|
     chain.add Sidekiq::Debounce
+    chain.add Sidekiq::Middleware::Server::CurrentUser
     chain.add Sidekiq::Middleware::Server::Chewy
     chain.add Sidekiq::Middleware::Server::LibratoMetrics if defined? Librato
+  end
+  config.client_middleware do |chain|
+    chain.add Sidekiq::Middleware::Client::CurrentUser
   end
 end
 
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'] }
+
+  config.client_middleware do |chain|
+    chain.add Sidekiq::Middleware::Client::CurrentUser
+  end
 end

--- a/lib/buffered_stream_client.rb
+++ b/lib/buffered_stream_client.rb
@@ -1,0 +1,71 @@
+# This class is wrapper for {Stream::Client} which provides buffering of actions to be executed en
+# masse using Stream's bulk APIs.  For example, if a single request makes multiple follow requests,
+# we can bundle those up into a single hit to the Stream API and thus make execution more efficient.
+# Of course, as with everything else, there's a cost: order of execution is a bit unpredictable, but
+# if there's code relying on order of execution with synchronization of data to Stream then it's
+# probably bad anyways.
+class BufferedStreamClient
+  attr_reader :client
+
+  # @param client [Stream::Client] the client to wrap
+  def initialize(client)
+    @client = client
+  end
+
+  # @api getstream-compat
+  # @param group [String,#to_s] the feed group
+  # @param id [String,#to_s] the feed id
+  # @return [JournaledFeed] the feed object
+  def feed(group, id)
+    BufferedFeed.new(group, id, self)
+  end
+
+  # @api getstream-compat
+  delegate :update_activities, to: :@feed
+
+  # @api getstream-compat
+  # @param follows [Array<Hash>] list of {source:, target:} follows
+  # @param scrollback [Integer] number of past posts to get from each feed
+  # @return [Hash] a hash with the execution duration
+  def follow_many(follows, scrollback)
+    duration { follow_buffer.push(scrollback, follows) }
+  end
+
+  # Asynchronously flush the queues to Sidekiq
+  #
+  # @return [void]
+  def flush_async
+    activity_buffer.flush_async
+    follow_buffer.flush_async
+  end
+
+  # Generate a realistic timing response hash in case anything depends on that
+  #
+  # @private
+  def self.duration(&block)
+    duration = Benchmark.realtime(&block)
+    ms = (duration * 1000).round
+    { duration: "#{ms}ms" }
+  end
+  delegate :duration, to: :class
+
+  # @private
+  def activity_buffer
+    Thread.current[activity_buffer_key] ||= ActivityBuffer.new
+  end
+
+  # @private
+  def follow_buffer
+    Thread.current[follow_buffer_key] ||= FollowBuffer.new
+  end
+
+  private
+
+  def follow_buffer_key
+    :"_#{object_id}_follows"
+  end
+
+  def activity_buffer_key
+    :"_#{object_id}_activities"
+  end
+end

--- a/lib/buffered_stream_client/action_buffer.rb
+++ b/lib/buffered_stream_client/action_buffer.rb
@@ -1,0 +1,40 @@
+class BufferedStreamClient
+  # A class for wrapping the buffering of actions to be executed by the client
+  class ActionBuffer
+    # @param queue [Hash] the queue data to preload
+    def initialize(queue = Hash.new { [] })
+      @queue = queue
+    end
+
+    # Add something to the queue
+    #
+    # @param key [Object] the key to group the queued items with
+    # @param items [Array<Hash>] the items to push into the queue
+    # @return [void]
+    def push(key, *items)
+      @queue[key] += Array.wrap(items)
+    end
+
+    # Return the queued data and then eset the queue to its default (empty) state
+    #
+    # @return [Hash<Object,Array>] the queued data
+    def reset
+      @queue.tap { @queue = Hash.new { [] } }
+    end
+
+    # Flush the queued data to the Stream API
+    #
+    # @param client [Stream::Client] the client to wrap
+    # @return [void]
+    def flush(_client)
+      raise NotImplementedError
+    end
+
+    # Asynchronously flush the queued data to the stream API
+    #
+    # @return [void]
+    def flush_async
+      BufferFlushWorker.perform_async(self.class.name, @queue)
+    end
+  end
+end

--- a/lib/buffered_stream_client/activity_buffer.rb
+++ b/lib/buffered_stream_client/activity_buffer.rb
@@ -1,0 +1,24 @@
+class BufferedStreamClient
+  class ActivityBuffer < ActionBuffer
+    BULK_THRESHOLD = 2
+
+    def flush(client)
+      reset.tap do |queue|
+        # Iterate over each feed and submit the activities for it
+        queue.each do |feed, activities|
+          group, id = feed.split(':')
+          feed = client.feed(group, id)
+
+          # If there's not many, send them individually to avoid triggering rate limits
+          if activities.count <= BULK_THRESHOLD
+            activities.each do |activity|
+              feed.add_activity(activity)
+            end
+          else
+            feed.add_activities(activities)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/buffered_stream_client/buffered_feed.rb
+++ b/lib/buffered_stream_client/buffered_feed.rb
@@ -1,0 +1,67 @@
+class StreamJournal
+  class BufferedFeed
+    # @private
+    delegate :duration, to: BufferedStreamClient
+
+    # @api getstream-compat
+    delegate :readonly_token, to: :@feed
+    delegate :get, to: :@feed
+    delegate :following, to: :@feed
+    delegate :followers, to: :@feed
+
+    # @private
+    # @param group [String,#to_s] the feed group
+    # @param id [String,#to_s] the feed id
+    # @param client [BufferedStreamClient] the client to buffer in
+    def initialize(group, id, buffer)
+      @group = group
+      @id = id
+      @buffer = buffer
+      @feed = buffer.client.feed(group, id)
+    end
+
+    # @api getstream-compat
+    # @param activities [Array<Hash>] the activity object
+    # @return [Hash] a hash with the execution duration
+    def add_activity(*activities)
+      duration do
+        activities = Array.wrap(activities).as_json
+        @buffer.activity_buffer.push(feed, *activities)
+      end
+    end
+    alias_method :add_activities, :add_activity
+
+    # @api getstream-compat
+    # @return [Hash] a hash with the execution duration
+    def remove_activity(*args)
+      perform_action :unfollow, *args
+    end
+
+    # @api getstream-compat
+    # @return [Hash] a hash with the execution duration
+    def unfollow(*args)
+      perform_action :unfollow, *args
+    end
+
+    # @api getstream-compat
+    # @param group [String,#to_s] the feed group
+    # @param id [String,#to_s] the feed id
+    # @param activity_copy_limit [Integer] the number of activities to copy
+    # @return [Hash] a hash with the execution duration
+    def follow(group, id, activity_copy_limit: 300)
+      duration do
+        @buffer.follow_buffer.push(activity_copy_limit,
+          source: "#{@group}:#{@id}",
+          target: "#{group}:#{id}")
+      end
+    end
+
+    private
+
+    def perform_action(action, *args)
+      duration do
+        BufferActionWorker.perform_async(@group, @id, action, *args)
+      end
+    end
+  end
+end

--- a/lib/buffered_stream_client/follow_buffer.rb
+++ b/lib/buffered_stream_client/follow_buffer.rb
@@ -1,0 +1,23 @@
+class BufferedStreamClient
+  class FollowBuffer < ActionBuffer
+    BULK_THRESHOLD = 2
+
+    def flush(client)
+      reset.tap do |queue|
+        # Iterate over the scrollback sizes
+        queue.each do |scrollback, follows|
+          # If there's not many, send them individually to avoid triggering rate limits
+          if follows.count <= BULK_THRESHOLD
+            follows.each do |follow|
+              group, id = follow[:source].split(':')
+              feed = client.feed(group, id)
+              feed.follow(follow[:target], activity_copy_limit: scrollback)
+            end
+          else
+            client.follow_many(*follows, activity_copy_limit: scrollback)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/middleware/client/current_user.rb
+++ b/lib/sidekiq/middleware/client/current_user.rb
@@ -1,0 +1,12 @@
+module Sidekiq
+  module Middleware
+    module Client
+      class CurrentUser
+        def call(_, job, *)
+          job['current_user'] = User.current&.id
+          yield
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/middleware/server/current_user.rb
+++ b/lib/sidekiq/middleware/server/current_user.rb
@@ -1,0 +1,20 @@
+module Sidekiq
+  module Middleware
+    module Server
+      class CurrentUser
+        def call(_, job, _)
+          # Extract the User ID from job metadata
+          user = User.find_by(id: job['current_user'])
+          # Save it onto the thread
+          Thread.current[:current_user] = user
+          # Send it to Raven
+          Raven.user_context(id: user.id, name: user.name) if user
+          # Run Sidekiq job
+          yield
+        ensure
+          Thread.current[:current_user] = nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
`BufferedStreamClient` is a wrapper for `Stream::Client` which buffers actions/follows/activities during a request and then flushes them to a Sidekiq task at the end of the request.  It will intelligently use non-bulk APIs when possible, and allows us to have have unified retry logic

**Pros:** less likely to hit rate-limits, better stability, allows for easy retrying
**Cons:** feedback is less immediate, all Stream APIs appear to succeed immediately, and the order of execution is unpredictable

Really the only "con" that's actually an issue for us is the order of execution — we never check for Stream failures and we already handle quick feed-post feedback clientside anyways.

# To Do

* [x] Enable this under a feature flag~