### PR TITLE
Stop sending progress events to feeds

### DIFF
--- a/app/models/library_entry.rb
+++ b/app/models/library_entry.rb
@@ -217,8 +217,6 @@ class LibraryEntry < ApplicationRecord
     unless imported || private?
       activity.rating(rating)&.create if rating_changed? && rating.present?
       activity.status(status)&.create if status_changed?
-      # If the progress has changed, make an activity unless status is changing to completed
-      activity.progress(progress)&.create if progress_changed? && !(status_changed? && completed?)
       media.trending_vote(user, 0.5) if progress_changed?
       media.trending_vote(user, 1.0) if status_changed?
     end

--- a/app/services/library_event_service.rb
+++ b/app/services/library_event_service.rb
@@ -1,12 +1,12 @@
 # Takes a dirtied LibraryEntry and generates a list of LibraryEvents for the changes
 class LibraryEventService
   # The change values to store in the event
-  CHANGES_FOR_EVENT ||= {
-    rated: %i[rating],
-    progressed: %i[progress reconsume_count volumes_owned time_spent],
-    updated: %i[status reconsume_count],
-    reacted: %i[media_reaction_id],
-    annotated: %i[notes]
+  CHANGES_FOR_EVENT = {
+    rated: %w[rating],
+    progressed: %w[progress reconsume_count volumes_owned time_spent],
+    updated: %w[status reconsume_count],
+    reacted: %w[media_reaction_id],
+    annotated: %w[notes]
   }.freeze
 
   # @param library_entry [LibraryEntry] the dirty LibraryEntry to figure out events for
@@ -51,7 +51,7 @@ class LibraryEventService
   def event_for(kind)
     LibraryEvent.new(
       kind: kind,
-      changed_data: @entry.changes.slice(CHANGES_FOR_EVENT[kind]),
+      changed_data: @entry.changes.slice(*CHANGES_FOR_EVENT[kind]),
       library_entry_id: @entry.id,
       anime_id: @entry.anime_id,
       manga_id: @entry.manga_id,

--- a/app/services/media_activity_service.rb
+++ b/app/services/media_activity_service.rb
@@ -25,16 +25,6 @@ class MediaActivityService
     )
   end
 
-  def progress(progress, unit = nil)
-    return if progress.zero?
-    fill_defaults user.profile_feed.activities.new(
-      verb: 'progressed',
-      foreign_id: "LibraryEntry:#{library_entry.id}:progressed-#{progress}",
-      progress: progress,
-      unit: unit
-    )
-  end
-
   def reviewed(review)
     fill_defaults user.profile_feed.activities.new(
       foreign_id: review,

--- a/spec/services/media_activity_service_spec.rb
+++ b/spec/services/media_activity_service_spec.rb
@@ -19,13 +19,6 @@ RSpec.describe MediaActivityService do
     end
   end
 
-  describe '#progress' do
-    it 'returns an activity for the user\'s media feed' do
-      expect(subject.progress(1).feed)
-        .to eq(library_entry.user.profile_feed)
-    end
-  end
-
   describe '#reviewed' do
     let(:review) { build(:review, library_entry: library_entry) }
 


### PR DESCRIPTION
Progress events clog up feeds without adding significant value.  Most users seem to stay to "User Activity" filter and honestly, the only good usage (see what your friends are watching) is better served by a trending system.