### PR TITLE
Don't use count guess when nil

### DIFF
--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -141,7 +141,8 @@ class Anime < ApplicationRecord
   end
 
   after_save do
-    if episode_count_guess_changed? && episodes.length != episode_count_guess
+    if (episode_count_guess_changed? && episode_count_guess != nil) &&
+        episodes.length != episode_count_guess
       episodes.create_defaults(episode_count_guess || 0)
     elsif episode_count_changed? && episodes.length != episode_count
       episodes.create_defaults(episode_count || 0)

--- a/app/models/anime.rb
+++ b/app/models/anime.rb
@@ -141,8 +141,8 @@ class Anime < ApplicationRecord
   end
 
   after_save do
-    if (episode_count_guess_changed? && episode_count_guess != nil) &&
-        episodes.length != episode_count_guess
+    if (episode_count_guess_changed? && !episode_count_guess.nil?) &&
+       episodes.length != episode_count_guess
       episodes.create_defaults(episode_count_guess || 0)
     elsif episode_count_changed? && episodes.length != episode_count
       episodes.create_defaults(episode_count || 0)

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -96,7 +96,8 @@ class Manga < ApplicationRecord
   end
 
   after_save do
-    if chapter_count_guess_changed? && chapters.length != chapter_count_guess
+    if (chapter_count_guess_changed? && chapter_count_guess != nil) &&
+        chapters.length != chapter_count_guess
       chapters.create_defaults(chapter_count_guess || 0)
     elsif chapter_count_changed? && chapters.length != chapter_count
       chapters.create_defaults(chapter_count || 0)

--- a/app/models/manga.rb
+++ b/app/models/manga.rb
@@ -96,8 +96,8 @@ class Manga < ApplicationRecord
   end
 
   after_save do
-    if (chapter_count_guess_changed? && chapter_count_guess != nil) &&
-        chapters.length != chapter_count_guess
+    if (chapter_count_guess_changed? && !chapter_count_guess.nil?) &&
+       chapters.length != chapter_count_guess
       chapters.create_defaults(chapter_count_guess || 0)
     elsif chapter_count_changed? && chapters.length != chapter_count
       chapters.create_defaults(chapter_count || 0)


### PR DESCRIPTION
Ref: https://kitsu.canny.io/bugs/p/setting-a-total-count-removes-the-chaptersepisodes-the-guess-created

I think this should fix the above issue where setting an episode or chapter count when the count guess is set will delete all the associated episodes/chapters.