### PR TITLE
Fix filter by kind for library events

### DIFF
--- a/app/resources/library_event_resource.rb
+++ b/app/resources/library_event_resource.rb
@@ -10,5 +10,9 @@ class LibraryEventResource < BaseResource
   has_one :drama
 
   filter :user_id
-  filter :kind
+
+  filter :kind, apply: ->(records, values, _opts) {
+    values = values.map { |v| records.kinds[v] || v }
+    records.where(kind: values)
+  }
 end


### PR DESCRIPTION
I think this should fix the following issue:
https://kitsu.canny.io/bugs/p/library-events-cant-be-filtered-by-kind