### PR TITLE
Add Initial GraphQL Setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -226,6 +226,10 @@ Style/RescueModifier:
   Enabled: true
 Style/SelfAssignment:
   Enabled: true
+Style/ClassAndModuleChildren:
+  Enabled: true
+  Exclude:
+  - app/graphql/**/*
 Layout/SpaceBeforeFirstArg:
   Enabled: true
 Layout/SpaceAfterColon:

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,10 @@ gem 'flipper'
 gem 'flipper-redis'
 gem 'flipper-ui'
 
+# API Frameworks
+gem 'graphql'
+gem 'jsonapi-resources', '0.9.0'
+
 # Miscellaneous Utilities
 gem 'addressable' # Fancy address logic
 gem 'counter_culture' # Fancier counter caches
@@ -63,7 +67,6 @@ gem 'fastimage' # Quickly get image sizes
 gem 'friendly_id' # slug-urls-are-cool
 gem 'google-api-client' # Google APIs
 gem 'ice_cube' # Episode release schedules
-gem 'jsonapi-resources', '0.9.0'
 gem 'lograge' # Non-shitty logging
 gem 'mechanize' # Automating interaction with websites
 gem 'nokogiri', '~> 1.8.4' # Parse MAL XML shit
@@ -105,6 +108,7 @@ gem 'sinatra' # used by sidekiq/web
 group :development, :test do
   gem 'annotate' # Schema annotations inside model-related files
   gem 'dotenv-rails' # Load default ENV
+  gem 'graphiql-rails' # GraphQL console
   gem 'pry-rails' # Better Console
   gem 'spring' # Faster CLI
 

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'flipper-ui'
 
 # API Frameworks
 gem 'graphql'
+gem 'graphql-batch'
 gem 'jsonapi-resources', '0.9.0'
 
 # Miscellaneous Utilities

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,6 +239,9 @@ GEM
       railties
       sprockets-rails
     graphql (1.8.6)
+    graphql-batch (0.3.10)
+      graphql (>= 0.8, < 2)
+      promise.rb (~> 0.7.2)
     groupdate (4.0.1)
       activesupport (>= 4.2)
     guard (2.14.2)
@@ -408,6 +411,7 @@ GEM
     pghero (2.2.0)
       activerecord
     progress (3.4.0)
+    promise.rb (0.7.4)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -693,6 +697,7 @@ DEPENDENCIES
   google-api-client
   graphiql-rails
   graphql
+  graphql-batch
   guard
   guard-rspec
   hiredis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,9 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
+    graphiql-rails (1.4.11)
+      railties
+      sprockets-rails
     graphql (1.8.6)
     groupdate (4.0.1)
       activesupport (>= 4.2)
@@ -688,6 +691,7 @@ DEPENDENCIES
   forest_liana
   friendly_id
   google-api-client
+  graphiql-rails
   graphql
   guard
   guard-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
+    graphql (1.8.6)
     groupdate (4.0.1)
       activesupport (>= 4.2)
     guard (2.14.2)
@@ -687,6 +688,7 @@ DEPENDENCIES
   forest_liana
   friendly_id
   google-api-client
+  graphql
   guard
   guard-rspec
   hiredis
@@ -764,4 +766,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,4 +1,6 @@
 class GraphqlController < ApplicationController
+  skip_after_action :enforce_policy_use
+
   def execute
     variables = ensure_hash(params[:variables])
     query = params[:query]

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,0 +1,43 @@
+class GraphqlController < ApplicationController
+  def execute
+    variables = ensure_hash(params[:variables])
+    query = params[:query]
+    operation_name = params[:operationName]
+    context = {
+      # Query context goes here, for example:
+      # current_user: current_user,
+    }
+    result = KitsuSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    render json: result
+  rescue => e
+    raise e unless Rails.env.development?
+    handle_error_in_development e
+  end
+
+  private
+
+  # Handle form data, JSON body, or a blank value
+  def ensure_hash(ambiguous_param)
+    case ambiguous_param
+    when String
+      if ambiguous_param.present?
+        ensure_hash(JSON.parse(ambiguous_param))
+      else
+        {}
+      end
+    when Hash, ActionController::Parameters
+      ambiguous_param
+    when nil
+      {}
+    else
+      raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
+    end
+  end
+
+  def handle_error_in_development(e)
+    logger.error e.message
+    logger.error e.backtrace.join("\n")
+
+    render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
+  end
+end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -9,9 +9,12 @@ class GraphqlController < ApplicationController
       # Query context goes here, for example:
       # current_user: current_user,
     }
-    result = KitsuSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
+    result = KitsuSchema.execute(query,
+      variables: variables,
+      context: context,
+      operation_name: operation_name)
     render json: result
-  rescue => e
+  rescue StandardError => e
     raise e unless Rails.env.development?
     handle_error_in_development e
   end
@@ -36,10 +39,16 @@ class GraphqlController < ApplicationController
     end
   end
 
-  def handle_error_in_development(e)
-    logger.error e.message
-    logger.error e.backtrace.join("\n")
+  def handle_error_in_development(exception)
+    logger.error exception.message
+    logger.error exception.backtrace.join("\n")
 
-    render json: { error: { message: e.message, backtrace: e.backtrace }, data: {} }, status: 500
+    render json: {
+      error: {
+        message: exception.message,
+        backtrace: exception.backtrace
+      },
+      data: {}
+    }, status: 500
   end
 end

--- a/app/graphql/concerns/has_localized_field.rb
+++ b/app/graphql/concerns/has_localized_field.rb
@@ -1,0 +1,31 @@
+module HasLocalizedField
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def localized_field(key, **options)
+      options = {
+        type: Types::Map,
+        null: false
+      }.merge(options)
+
+      field(key, options) do
+        argument :locales, [String], required: false
+
+        yield if block_given?
+      end
+
+      define_method(key) do |**params|
+        locales = params[:locales]
+        # TODO: fall back to Accept-Language header by default?
+        titles = if object.respond_to?(key)
+                   object.public_send(key)
+                 elsif object.respond_to?(:key?) && object.key?(key)
+                   object[key]
+                 else super
+                 end
+        titles = titles.slice(*locales) if locales
+        titles
+      end
+    end
+  end
+end

--- a/app/graphql/kitsu_schema.rb
+++ b/app/graphql/kitsu_schema.rb
@@ -1,0 +1,4 @@
+class KitsuSchema < GraphQL::Schema
+  mutation(Types::MutationType)
+  query(Types::QueryType)
+end

--- a/app/graphql/types/age_rating.rb
+++ b/app/graphql/types/age_rating.rb
@@ -1,0 +1,6 @@
+class Types::AgeRating < Types::BaseEnum
+  value 'G', 'Acceptable for all ages'
+  value 'PG', 'Parental guidance suggested; should be safe for preteens and older'
+  value 'R', 'Possible lewd or intense themes; should be safe for teens and older'
+  value 'R18', 'Contains adult content or themes; should only be viewed by adults'
+end

--- a/app/graphql/types/anime.rb
+++ b/app/graphql/types/anime.rb
@@ -1,0 +1,4 @@
+class Types::Anime < Types::BaseObject
+  implements Types::MediaInterface
+  implements Types::EpisodicInterface
+end

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,0 +1,2 @@
+class Types::BaseEnum < GraphQL::Schema::Enum
+end

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,0 +1,2 @@
+class Types::BaseInputObject < GraphQL::Schema::InputObject
+end

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,0 +1,3 @@
+module Types::BaseInterface
+  include GraphQL::Schema::Interface
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,0 +1,2 @@
+class Types::BaseObject < GraphQL::Schema::Object
+end

--- a/app/graphql/types/base_scalar.rb
+++ b/app/graphql/types/base_scalar.rb
@@ -1,0 +1,1 @@
+class Types::BaseScalar < GraphQL::Schema::Scalar; end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,0 +1,2 @@
+class Types::BaseUnion < GraphQL::Schema::Union
+end

--- a/app/graphql/types/date.rb
+++ b/app/graphql/types/date.rb
@@ -1,0 +1,14 @@
+class Types::Date < Types::BaseScalar
+  description "A date, expressed as an ISO8601 string"
+
+  def self.coerce_input(input_value, context)
+    Date.strptime(input_value, '%F')
+  rescue ArgumentError
+    raise GraphQL::CoercionError, "#{input_value.inspect} is not a valid date"
+  end
+
+  def self.coerce_result(ruby_value, context)
+    # It's transported as a string, so stringify it
+    ruby_value.strftime('%F')
+  end
+end

--- a/app/graphql/types/date.rb
+++ b/app/graphql/types/date.rb
@@ -1,13 +1,13 @@
 class Types::Date < Types::BaseScalar
-  description "A date, expressed as an ISO8601 string"
+  description 'A date, expressed as an ISO8601 string'
 
-  def self.coerce_input(input_value, context)
+  def self.coerce_input(input_value, _context)
     Date.strptime(input_value, '%F')
   rescue ArgumentError
     raise GraphQL::CoercionError, "#{input_value.inspect} is not a valid date"
   end
 
-  def self.coerce_result(ruby_value, context)
+  def self.coerce_result(ruby_value, _context)
     # It's transported as a string, so stringify it
     ruby_value.strftime('%F')
   end

--- a/app/graphql/types/episode.rb
+++ b/app/graphql/types/episode.rb
@@ -1,0 +1,42 @@
+class Types::Episode < Types::BaseObject
+  description 'An Episode of a Media'
+
+  field :id, ID, null: false
+
+  field :titles, Types::TitlesList,
+    null: false,
+    description: 'The titles for this episode in various locales'
+
+  def titles
+    {
+      localized: object.titles,
+      canonical: object.canonical_title
+    }
+  end
+
+  field :number, Integer,
+    null: false,
+    description: 'The sequence number of this episode in the season'
+
+  field :synopsis, [Types::LocalizedString],
+    null: true,
+    description: 'A brief summary or description of the episode'
+
+  def synopsis
+    # TODO: actually store localized synopsis data
+    [{ locale: 'en', text: object.synopsis }] if object.synopsis
+  end
+
+  field :length, Integer,
+    null: true,
+    description: 'The length of the Episode in seconds'
+
+  field :aired_at, GraphQL::Types::ISO8601DateTime,
+    null: true,
+    description: 'The time when the episode aired',
+    method: :airdate
+
+  field :thumbnail, Types::Image,
+    null: true,
+    description: 'A thumbnail image for the episode'
+end

--- a/app/graphql/types/episodic_interface.rb
+++ b/app/graphql/types/episodic_interface.rb
@@ -1,0 +1,14 @@
+module Types::EpisodicInterface
+  include Types::BaseInterface
+  description 'An episodic media in the Kitsu database'
+
+  field :episode_count, Integer,
+    null: true,
+    description: 'The number of episodes in this series'
+  field :episode_length, Integer,
+    null: true,
+    description: 'The general length (in seconds) of each episode'
+  field :total_length, Integer,
+    null: true,
+    description: 'The total length (in seconds) of the entire series'
+end

--- a/app/graphql/types/episodic_interface.rb
+++ b/app/graphql/types/episodic_interface.rb
@@ -5,10 +5,23 @@ module Types::EpisodicInterface
   field :episode_count, Integer,
     null: true,
     description: 'The number of episodes in this series'
+
   field :episode_length, Integer,
     null: true,
     description: 'The general length (in seconds) of each episode'
+
   field :total_length, Integer,
     null: true,
     description: 'The total length (in seconds) of the entire series'
+
+  field :episodes, Types::Episode.connection_type, null: false do
+    description 'Episodes for this media'
+    argument :number, [Integer], required: false
+  end
+
+  def episodes(number: nil)
+    episodes = object.episodes
+    episodes = episodes.where(number: number) if number
+    episodes.order(number: :asc)
+  end
 end

--- a/app/graphql/types/image.rb
+++ b/app/graphql/types/image.rb
@@ -1,0 +1,32 @@
+class Types::Image < Types::BaseObject
+  field :original, Types::ImageView,
+    null: false,
+    description: 'The original image'
+
+  field :views, [Types::ImageView],
+    null: false,
+    description: 'The various generated views of this image' do
+      argument :names, [String], required: false
+    end
+
+  def original
+    {
+      name: 'original',
+      url: object.url(:original),
+      width: object.width(:original),
+      height: object.height(:original)
+    }
+  end
+
+  def views(names: object.styles.keys)
+    styles = object.styles.keys
+    (names.map(&:to_sym) & styles).map do |style|
+      {
+        name: style,
+        url: object.url(style),
+        width: object.width(style),
+        height: object.height(style)
+      }
+    end
+  end
+end

--- a/app/graphql/types/image_view.rb
+++ b/app/graphql/types/image_view.rb
@@ -1,0 +1,17 @@
+class Types::ImageView < Types::BaseObject
+  field :name, String,
+    null: false,
+    description: 'The name of this view of the image'
+
+  field :url, String,
+    null: false,
+    description: 'The URL of this view of the image'
+
+  field :width, Integer,
+    null: true,
+    description: 'The width of the image'
+
+  field :height, Integer,
+    null: true,
+    description: 'The height of the image'
+end

--- a/app/graphql/types/localized_string.rb
+++ b/app/graphql/types/localized_string.rb
@@ -1,0 +1,8 @@
+class Types::LocalizedString < Types::BaseObject
+  field :locale, String,
+    null: false,
+    description: 'The IETF/BCP 47 locale tag for this string'
+  field :text, String,
+    null: false,
+    description: 'The text value of this string'
+end

--- a/app/graphql/types/map.rb
+++ b/app/graphql/types/map.rb
@@ -1,0 +1,11 @@
+class Types::Map < Types::BaseScalar
+  description 'A loose key-value map in GraphQL'
+
+  def self.coerce_input(input_value, _context)
+    input_value
+  end
+
+  def self.coerce_result(ruby_value, _context)
+    ruby_value.as_json
+  end
+end

--- a/app/graphql/types/media_interface.rb
+++ b/app/graphql/types/media_interface.rb
@@ -1,0 +1,73 @@
+module Types::MediaInterface
+  include Types::BaseInterface
+  description 'A media in the Kitsu database'
+
+  field :id, ID, null: false
+  field :slug, String,
+    null: false,
+    description: 'The URL-friendly identifier of this media'
+
+  field :titles, Types::TitlesList,
+    null: false,
+    description: 'The titles for this media in various locales'
+
+  field :synopsis, [Types::LocalizedString],
+    null: false,
+    description: 'A brief (mostly spoiler-free) summary/description of the media'
+
+  field :age_rating, Types::AgeRating,
+    null: true,
+    description: 'The recommended minimum age group for this media'
+  field :age_rating_guide, String,
+    null: true,
+    description: 'An explanation of why this received the age rating it did'
+
+  field :start_date, Types::Date,
+    null: true,
+    description: 'The day that this media first released'
+  field :end_date, Types::Date,
+    null: true,
+    description: 'the day that this media made its final release'
+  field :next_release, GraphQL::Types::ISO8601DateTime,
+    null: true,
+    description: 'The time of the next release of this media'
+  field :status, Types::ReleaseStatus,
+    null: false,
+    description: 'The current releasing status of this media'
+
+  field :average_rating, Float,
+    null: true,
+    description: 'The average rating of this media amongst all Kitsu users'
+  field :user_count, Integer,
+    null: true,
+    description: 'The number of users with this in their library'
+  field :favorites_count, Integer,
+    null: true,
+    description: 'The number of users with this in their favorites'
+
+  field :poster_image, Types::Image,
+    null: false,
+    description: 'The poster image of this media'
+
+=begin
+  field :poster_image, Types::Image,
+    null: true,
+    description: 'The poster image for the media'
+  field :cover_image, Types::Image,
+    null: true,
+    description: 'The cover image for the media (not the poster image)'
+=end
+
+  def titles
+    {
+      localized: object.titles,
+      alternatives: object.abbreviated_titles,
+      canonical: object.canonical_title
+    }
+  end
+
+  def synopsis
+    # TODO: actually store more synopsis data than this
+    [{ locale: 'en', text: object.synopsis }]
+  end
+end

--- a/app/graphql/types/media_interface.rb
+++ b/app/graphql/types/media_interface.rb
@@ -2,61 +2,17 @@ module Types::MediaInterface
   include Types::BaseInterface
   description 'A media in the Kitsu database'
 
+  # Identifiers
   field :id, ID, null: false
+
   field :slug, String,
     null: false,
     description: 'The URL-friendly identifier of this media'
 
+  # Localized Titles
   field :titles, Types::TitlesList,
     null: false,
     description: 'The titles for this media in various locales'
-
-  field :synopsis, [Types::LocalizedString],
-    null: false,
-    description: 'A brief (mostly spoiler-free) summary/description of the media'
-
-  field :age_rating, Types::AgeRating,
-    null: true,
-    description: 'The recommended minimum age group for this media'
-  field :age_rating_guide, String,
-    null: true,
-    description: 'An explanation of why this received the age rating it did'
-
-  field :start_date, Types::Date,
-    null: true,
-    description: 'The day that this media first released'
-  field :end_date, Types::Date,
-    null: true,
-    description: 'the day that this media made its final release'
-  field :next_release, GraphQL::Types::ISO8601DateTime,
-    null: true,
-    description: 'The time of the next release of this media'
-  field :status, Types::ReleaseStatus,
-    null: false,
-    description: 'The current releasing status of this media'
-
-  field :average_rating, Float,
-    null: true,
-    description: 'The average rating of this media amongst all Kitsu users'
-  field :user_count, Integer,
-    null: true,
-    description: 'The number of users with this in their library'
-  field :favorites_count, Integer,
-    null: true,
-    description: 'The number of users with this in their favorites'
-
-  field :poster_image, Types::Image,
-    null: false,
-    description: 'The poster image of this media'
-
-=begin
-  field :poster_image, Types::Image,
-    null: true,
-    description: 'The poster image for the media'
-  field :cover_image, Types::Image,
-    null: true,
-    description: 'The cover image for the media (not the poster image)'
-=end
 
   def titles
     {
@@ -66,8 +22,67 @@ module Types::MediaInterface
     }
   end
 
+  # Localized Synopsis
+  field :synopsis, [Types::LocalizedString],
+    null: false,
+    description: 'A brief (mostly spoiler-free) summary/description of the media'
+
   def synopsis
-    # TODO: actually store more synopsis data than this
-    [{ locale: 'en', text: object.synopsis }]
+    # TODO: actually store localized synopsis data
+    [{ locale: 'en', text: object.synopsis }] if object.synopsis
   end
+
+  # Age Rating
+  field :age_rating, Types::AgeRating,
+    null: true,
+    description: 'The recommended minimum age group for this media'
+
+  field :age_rating_guide, String,
+    null: true,
+    description: 'An explanation of why this received the age rating it did'
+
+  field :sfw, Boolean,
+    null: false,
+    description: 'Whether the media is Safe-for-Work',
+    method: :sfw?
+
+  # Release Information
+  field :start_date, Types::Date,
+    null: true,
+    description: 'The day that this media first released'
+
+  field :end_date, Types::Date,
+    null: true,
+    description: 'the day that this media made its final release'
+
+  field :next_release, GraphQL::Types::ISO8601DateTime,
+    null: true,
+    description: 'The time of the next release of this media'
+
+  field :status, Types::ReleaseStatus,
+    null: false,
+    description: 'The current releasing status of this media'
+
+  # User Ratings
+  field :average_rating, Float,
+    null: true,
+    description: 'The average rating of this media amongst all Kitsu users'
+
+  field :user_count, Integer,
+    null: true,
+    description: 'The number of users with this in their library'
+
+  field :favorites_count, Integer,
+    null: true,
+    description: 'The number of users with this in their favorites'
+
+  # Images
+  field :poster_image, Types::Image,
+    null: false,
+    description: 'The poster image of this media'
+
+  field :banner_image, Types::Image,
+    method: :cover_image,
+    null: false,
+    description: 'A large banner image for this media'
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,0 +1,8 @@
+class Types::MutationType < Types::BaseObject
+  # TODO: remove me
+  field :test_field, String, null: false,
+    description: "An example field added by the generator"
+  def test_field
+    "Hello World"
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,8 +1,2 @@
 class Types::MutationType < Types::BaseObject
-  # TODO: remove me
-  field :test_field, String, null: false,
-    description: "An example field added by the generator"
-  def test_field
-    "Hello World"
-  end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,0 +1,11 @@
+class Types::QueryType < Types::BaseObject
+  # Add root-level fields here.
+  # They will be entry points for queries on your schema.
+
+  # TODO: remove me
+  field :test_field, String, null: false,
+    description: "An example field added by the generator"
+  def test_field
+    "Hello World!"
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,10 +2,17 @@ class Types::QueryType < Types::BaseObject
   # Add root-level fields here.
   # They will be entry points for queries on your schema.
 
-  # TODO: remove me
-  field :test_field, String, null: false,
-    description: "An example field added by the generator"
-  def test_field
-    "Hello World!"
+  field :anime, Types::Anime.connection_type, null: false do
+    description 'Anime in the Kitsu database'
+    argument :slug, [String], required: false
+    argument :id, [String], required: false
+  end
+
+  def anime(slug: nil, id: nil)
+    if slug
+      Anime.by_slug(slug)
+    elsif id
+      Anime.find(id)
+    end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -10,9 +10,9 @@ class Types::QueryType < Types::BaseObject
 
   def anime(slug: nil, id: nil)
     if slug
-      Anime.by_slug(slug)
+      ::Anime.by_slug(slug)
     elsif id
-      Anime.find(id)
+      ::Anime.find(id)
     end
   end
 end

--- a/app/graphql/types/release_status.rb
+++ b/app/graphql/types/release_status.rb
@@ -1,0 +1,7 @@
+class Types::ReleaseStatus < Types::BaseEnum
+  value 'TBA', 'The release date has not been announced yet', value: :tba
+  value 'FINISHED', 'This media is no longer releasing', value: :finished
+  value 'CURRENT', 'This media is currently releasing', value: :current
+  value 'UPCOMING', 'This media is releasing soon', value: :upcoming
+  value 'UNRELEASED', 'This media is not released yet', value: :unreleased
+end

--- a/app/graphql/types/titles_list.rb
+++ b/app/graphql/types/titles_list.rb
@@ -1,0 +1,11 @@
+class Types::TitlesList < Types::BaseObject
+  field :localized, [Types::LocalizedString],
+    null: false,
+    description: 'The list of localized titles keyed by locale'
+  field :alternatives, [String],
+    null: false,
+    description: 'A list of additional, alternative, abbreviated, or unofficial titles'
+  field :canonical, String,
+    null: false,
+    description: 'The official or de facto international title'
+end

--- a/app/graphql/types/titles_list.rb
+++ b/app/graphql/types/titles_list.rb
@@ -1,6 +1,7 @@
 class Types::TitlesList < Types::BaseObject
-  field :localized, [Types::LocalizedString],
-    null: false,
+  include HasLocalizedField
+
+  localized_field :localized,
     description: 'The list of localized titles keyed by locale'
   field :alternatives, [String],
     null: false,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ require 'sidekiq/web'
 
 Rails.application.routes.draw do
   scope '/api' do
+    post '/graphql', to: 'graphql#execute'
     scope '/edge' do
       ### Users
       # These have to be first since they have precedence
@@ -185,6 +186,9 @@ Rails.application.routes.draw do
       mount Sidekiq::Web => '/sidekiq'
       mount PgHero::Engine => '/pghero'
       mount Flipper::UI.app(Flipper) => '/flipper'
+      if Rails.env.development?
+        mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/api/graphql'
+      end
     end
     get '/admin', to: 'sessions#redirect'
     get '/sidekiq', to: 'sessions#redirect'


### PR DESCRIPTION
# Why?

GraphQL is a significant improvement over json:api.  Frankly speaking, json:api sucks.  Especially on feeds.

# What?

This PR lays out some basic groundwork for GraphQL and gives us a starting point for the API.  It's not perfect, it's subject to huge flux, but with this we can start to use GraphQL for implementing things in other branches.

# Checklist

Because this is just the groundwork for implementation to begin elsewhere, there's not a whole lot else needed before we can merge this:

* [x] Install batching system
* [x] Finish anime type