### PR TITLE
Add profile links for Mastodon and XMPP/Jabber

### DIFF
--- a/db/seeds/profile_link_sites.yml
+++ b/db/seeds/profile_link_sites.yml
@@ -143,3 +143,13 @@ website:
   name: Website
   validate_find: '\A(?<protocol>https?:\/\/)(www.)?(?<url>(.)+)\z'
   validate_replace: '\k<protocol>\k<url>'
+mastodon:
+  id: 30
+  name: Mastodon
+  validate_find: '\A(?<protocol>https?://)(?<instance>.+\..+)(?<path>.*)\z'
+  validate_replace: '\k<protocol>\k<instance>\k<path>'
+xmpp:
+  id: 31
+  name: XMPP
+  validate_find: "\\A(?<localpart>[^@/<>'\"]+)@(?<domain>[^@/<>'\"]+)\\z"
+  validate_replace: '\k<localpart>@\k<domain>'

--- a/spec/factories/profile_link_sites.rb
+++ b/spec/factories/profile_link_sites.rb
@@ -191,6 +191,18 @@ FactoryBot.define do
       validate_find { '(?<protocol>https?://)(www.)?(?<url>(.)+\.(.)+)' }
       validate_replace { '\k<protocol\k<url>' }
     end
+
+    # Mastodon
+    trait :mastodon do
+      validate_find { '\A(?<protocol>https?://)(?<instance>.+\.[^/]+)(?<path>.*)\z' }
+      validate_replace { '\k<protocol\k<instance>\k<path>' }
+    end
+
+    # XMPP/Jabber
+    trait :xmpp do
+      validate_find { '\A(?<localpart>[^@/<>\'"]+)@(?<domain>[^@/<>\'"]+)\z' }
+      validate_replace { '\k<localpart>@\k<domain>' }
+    end
     # rubocop:enable Metrics/LineLength
   end
 end

--- a/spec/models/profile_link_site_spec.rb
+++ b/spec/models/profile_link_site_spec.rb
@@ -682,4 +682,54 @@ RSpec.describe ProfileLinkSite, type: :model do
       end
     end
   end # end of validate context
+
+  # Mastodon
+  describe 'Mastodon' do
+    context 'success' do
+      it 'should work with http' do
+        urls = %w[
+          http://niu.moe/@lumi
+        ]
+        site = build(:profile_link_site, :mastodon)
+
+        urls.each do |url|
+          temp = Regexp.new(site.validate_find).match(url)
+          expect(temp[:protocol]).to eq('http://')
+          expect(temp[:instance]).to eq('niu.moe')
+          expect(temp[:path]).to eq('/@lumi')
+        end
+      end
+      it 'should work with https' do
+        urls = %w[
+          https://niu.moe/@lumi
+        ]
+        site = build(:profile_link_site, :mastodon)
+
+        urls.each do |url|
+          temp = Regexp.new(site.validate_find).match(url)
+          expect(temp[:protocol]).to eq('https://')
+          expect(temp[:instance]).to eq('niu.moe')
+          expect(temp[:path]).to eq('/@lumi')
+        end
+      end
+    end
+  end
+
+  # XMPP/Jabber
+  describe 'XMPP/Jabber' do
+    context 'success' do
+      it 'should parse a JID correctly' do
+        urls = %w[
+          localpart@domain.tld
+        ]
+        site = build(:profile_link_site, :xmpp)
+
+        urls.each do |url|
+          temp = Regexp.new(site.validate_find).match(url)
+          expect(temp[:localpart]).to eq('localpart')
+          expect(temp[:domain]).to eq('domain.tld')
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What

This PR adds profile links for Mastodon and XMPP/Jabber.

I'm not sure whether this is the proper way of doing this, I tried to mimic the existing code.

This is the server side of https://github.com/hummingbird-me/hummingbird-client/pull/808

# Checklist

The changes I've made pass Rubocop and the tests I've written pass.

Rubocop complains about a lot of code that I did not touch. A bunch of tests that have nothing to do with my code are failing.

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [X] Any complex logic is commented
- [X] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [X] Tests have been added to cover the new code