### PR TITLE
Check reaction_skipped as string

### DIFF
--- a/app/services/library_gaps_service.rb
+++ b/app/services/library_gaps_service.rb
@@ -28,7 +28,7 @@ class LibraryGapsService
       rating: []
     ) do |(id, votes, reaction_skipped, reactions, ratings), out|
       out[:attributes] << id if votes.zero?
-      out[:reaction] << id if reactions.zero? && [0, 1].include?(reaction_skipped)
+      out[:reaction] << id if reactions.zero? && reaction_skipped != 'ignored'
       out[:rating] << id if ratings.zero?
     end
   end


### PR DESCRIPTION
In Rails 5 enums switch from returning as ints to strings. This was causing all entries to get excluded from the media reactions issues list.