### PR TITLE
Dirty change wrapper *_was fixes

### DIFF
--- a/lib/dirty_change_wrapper.rb
+++ b/lib/dirty_change_wrapper.rb
@@ -7,21 +7,22 @@ class DirtyChangeWrapper < SimpleDelegator
       define_singleton_method(key) { after }
       define_singleton_method("#{key}_was") { before }
       define_singleton_method("#{key}_changed?") { true }
-      define_singleton_method("#{key}_changes") { [before, after] }
+      define_singleton_method("#{key}_change") { [before, after] }
     end
   end
 
   def method_missing(method_name, *args)
     case method_name
     when /_changed\?\z/ then false
-    when /_changes\z/ then nil
+    when /_change\z/ then nil
+    when /_was\z/ then public_send(method_name.to_s.sub(/_was\z/, ''))
     else super
     end
   end
 
   def respond_to_missing?(method_name, _include_all)
     case method_name
-    when /_changed\?\z/, /_changes\z/ then true
+    when /_changed\?\z/, /_change\z/, /_was\z/ then true
     else super
     end
   end

--- a/spec/lib/dirty_change_wrapper_spec.rb
+++ b/spec/lib/dirty_change_wrapper_spec.rb
@@ -22,9 +22,16 @@ RSpec.describe DirtyChangeWrapper do
       expect(subject.baz_changed?).to be_truthy
     end
 
-    it 'should provide a _changes method to expose the raw change array' do
-      expect(subject).to respond_to(:baz_changes)
-      expect(subject.baz_changes).to eq(%w[bar bat])
+    it 'should provide a _change method to expose the raw change array' do
+      expect(subject).to respond_to(:baz_change)
+      expect(subject.baz_change).to eq(%w[bar bat])
+    end
+  end
+
+  context 'for unchanged properties' do
+    it 'should provide a _was method which returns the current value' do
+      expect(subject).to respond_to(:foo_was)
+      expect(subject.foo_was).to eq('bar')
     end
   end
 
@@ -34,9 +41,9 @@ RSpec.describe DirtyChangeWrapper do
       expect(subject.nope_changed?).to be_falsey
     end
 
-    it 'should provide a _changes method which returns nil' do
-      expect(subject).to respond_to(:nope_changes)
-      expect(subject.nope_changes).to be_nil
+    it 'should provide a _change method which returns nil' do
+      expect(subject).to respond_to(:nope_change)
+      expect(subject.nope_change).to be_nil
     end
   end
 


### PR DESCRIPTION
# What
Fixed `DirtyChangeWrapper` to support `*_was` even when it does not exist. It will now return the `*` instead of nil. 

# Why
- Stats should not add 1 when changing LibraryEntry rating (this only happened when status was :complete). This would lead to inaccurate stat calculations for anime_amount_consumed.


# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
