### PR TITLE
Update FB graph api

### DIFF
--- a/lib/authorization/assertion/facebook.rb
+++ b/lib/authorization/assertion/facebook.rb
@@ -4,7 +4,7 @@ module Authorization
       # The Aozora Facebook App ID
       AOZORA_FACEBOOK_APP_ID = '1467094533604194'.freeze
       # Facebook URL stuff
-      API_VERSION = 'v2.11'.freeze
+      API_VERSION = 'v6.0'.freeze
       URL_PREFIX = "https://graph.facebook.com/#{API_VERSION}".freeze
       URL_TEMPLATE = Addressable::Template.new("#{URL_PREFIX}/{+path*}{?query*}").freeze
       # The data to load from Facebook

--- a/spec/lib/authorization/assertion/facebook_spec.rb
+++ b/spec/lib/authorization/assertion/facebook_spec.rb
@@ -3,9 +3,9 @@ require 'authorization/assertion/facebook'
 
 RSpec.describe Authorization::Assertion::Facebook do
   before do
-    stub_request(:get, %r{https://graph.facebook.com/v2.11/me\?.*})
+    stub_request(:get, %r{https://graph.facebook.com/v6.0/me\?.*})
       .to_return(body: fixture('auth/facebook/self.json'))
-    stub_request(:get, %r{https://graph.facebook.com/v2.11/me/friends\?.*})
+    stub_request(:get, %r{https://graph.facebook.com/v6.0/me/friends\?.*})
       .to_return(body: fixture('auth/facebook/friends.json'))
   end
   let(:facebook_auth) { Authorization::Assertion::Facebook.new('any token') }


### PR DESCRIPTION
Swap Graph API v2.11 for the latest (v6.0)

Turns out no changes are necessary to the code, since we use so little of their API lol