### PR TITLE
Custom Field - batch_load_field

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,2 +1,11 @@
 class Types::BaseObject < GraphQL::Schema::Object
+  def self.batch_load_field(name, *args, association_name: nil, **kwargs, &block)
+    if instance_methods(false).exclude?(name)
+      define_method name do
+        AssociationLoader.for(object.class, association_name.presence || name).load(object)
+      end
+    end
+
+    field(name, *args, **kwargs, &block)
+  end
 end


### PR DESCRIPTION
# What
Create a new field type called `batch_load_field` to handle automatically creating the `AssociationLoader` method as to not pollute our Types with tons of `defs`

# Why

Cut down on duplicate code. This will automatically create the method that the `field` will call to grab all the association records. It will also check if the method exists (it shouldn't because then you wouldn't be using this method).

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
