### PR TITLE
Fix imgix purging

### DIFF
--- a/app/models/concerns/with_avatar.rb
+++ b/app/models/concerns/with_avatar.rb
@@ -25,8 +25,9 @@ module WithAvatar
         interpolator.interpolate(avatar.options[:url], avatar, :large)
       }
 
-      after_commit if: :avatar_updated_at_changed? do
-        ImgixPurgeService.purge(avatar.url(:original))
-      end
+    after_commit if: :avatar_updated_at_changed? do
+      url = avatar.url(:original).gsub('media.kitsu.io', 'kitsu-media.s3.amazonaws.com')
+      ImgixPurgeService.purge(url)
+    end
   end
 end

--- a/app/models/concerns/with_cover_image.rb
+++ b/app/models/concerns/with_cover_image.rb
@@ -24,7 +24,8 @@ module WithCoverImage
       }
 
     after_commit if: :cover_image_updated_at_changed? do
-      ImgixPurgeService.purge(cover_image.url(:original))
+      url = cover_image.url(:original).gsub('media.kitsu.io', 'kitsu-media.s3.amazonaws.com')
+      ImgixPurgeService.purge(url)
     end
   end
 end


### PR DESCRIPTION
So, it turns out, the imgix purge issue wasn't timing.  It was domain.

We pass the full URL to the purge API, and we're passing our alias (media.kitsu.io) instead of the S3 url.  This just very hackily replaces that so it points to s3 instead.