### PR TITLE
fix: allow dashes and underscores in SoundCloud profile

### DIFF
--- a/db/seeds/profile_link_sites.yml
+++ b/db/seeds/profile_link_sites.yml
@@ -66,7 +66,7 @@ tumblr:
 soundcloud:
   id: 14
   name: SoundCloud
-  validate_find: '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-z0-9\-]+)\z'
+  validate_find: '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-z0-9_\-]+)\z'
   validate_replace: 'https://soundcloud.com/\k<username>'
 dailymotion:
   id: 15

--- a/db/seeds/profile_link_sites.yml
+++ b/db/seeds/profile_link_sites.yml
@@ -66,7 +66,7 @@ tumblr:
 soundcloud:
   id: 14
   name: SoundCloud
-  validate_find: '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-z0-9]+)\z'
+  validate_find: '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-z0-9\-]+)\z'
   validate_replace: 'https://soundcloud.com/\k<username>'
 dailymotion:
   id: 15

--- a/spec/factories/profile_link_sites.rb
+++ b/spec/factories/profile_link_sites.rb
@@ -98,7 +98,7 @@ FactoryBot.define do
 
     # SoundCloud
     trait :soundcloud do
-      validate_find { '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-Z0-9]+)\z' }
+      validate_find { '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-Z0-9\-]+)\z' }
       validate_replace { 'https://soundcloud.com/\k<username>' }
     end
 

--- a/spec/factories/profile_link_sites.rb
+++ b/spec/factories/profile_link_sites.rb
@@ -98,7 +98,7 @@ FactoryBot.define do
 
     # SoundCloud
     trait :soundcloud do
-      validate_find { '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-Z0-9\-]+)\z' }
+      validate_find { '\A(https?://)?(www.)?(soundcloud.com/)?(?<username>[a-zA-Z0-9_\-]+)\z' }
       validate_replace { 'https://soundcloud.com/\k<username>' }
     end
 

--- a/spec/models/profile_link_site_spec.rb
+++ b/spec/models/profile_link_site_spec.rb
@@ -334,18 +334,16 @@ RSpec.describe ProfileLinkSite, type: :model do
       context 'success' do
         it 'should return a username' do
           urls = %w[
-            soundcloud.com/toyhammered
-            https://www.soundcloud.com/toyhammered
-            https://soundcloud.com/toyhammered
-            toyhammered
-            toy-hammered
-            toy_hammered
+            soundcloud.com/toy-hamme_red
+            https://www.soundcloud.com/toy-hamme_red
+            https://soundcloud.com/toy-hamme_red
+            toy-hamme_red
           ]
           site = build(:profile_link_site, :soundcloud)
 
           urls.each do |url|
             temp = site.validate_find.match(url)
-            expect(temp[:username]).to eq('toyhammered')
+            expect(temp[:username]).to eq('toy-hamme_red')
           end
         end
       end

--- a/spec/models/profile_link_site_spec.rb
+++ b/spec/models/profile_link_site_spec.rb
@@ -338,6 +338,8 @@ RSpec.describe ProfileLinkSite, type: :model do
             https://www.soundcloud.com/toyhammered
             https://soundcloud.com/toyhammered
             toyhammered
+            toy-hammered
+            toy_hammered
           ]
           site = build(:profile_link_site, :soundcloud)
 


### PR DESCRIPTION
# What

Allows _ and - in SoundCloud profile links.

# Why

SoundCloud allows a-z, A-Z, 0-9, - and _ in the slug.

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
