### PR TITLE
GraphQL - AssociationLoader with Pundit Scopes

### DIFF
--- a/app/graphql/association_loader.rb
+++ b/app/graphql/association_loader.rb
@@ -4,18 +4,19 @@ class AssociationLoader < GraphQL::Batch::Loader
     nil
   end
 
-  def initialize(model, association_name)
+  def initialize(model, association_name, token: nil, policy: nil)
     @model = model
     @association_name = association_name
+    @token = token
+    @policy = (policy.presence || association_name).to_s
+
     validate
   end
 
-  def load(record)
-    unless record.is_a?(@model)
-      raise TypeError, "#{@model} loader can't load association for #{record.class}"
+  def scope(record)
+    load(record).then do |associations|
+      Promise.resolve(policy_klass.new(token, associations).resolve)
     end
-    return Promise.resolve(read_association(record)) if association_loaded?(record)
-    super
   end
 
   # We want to load the associations on all records, even if they have the same id
@@ -30,10 +31,26 @@ class AssociationLoader < GraphQL::Batch::Loader
 
   private
 
+  attr_reader :token, :policy
+
+  # This will return a Promise which we will chain the pundit scope onto.
+  # All the cached data will be pre-pundit scoped.
+  def load(record)
+    unless record.is_a?(@model)
+      raise TypeError, "#{@model} loader can't load association for #{record.class}"
+    end
+    return Promise.resolve(read_association(record)) if association_loaded?(record)
+    super
+  end
+
   def validate
     unless @model.reflect_on_association(@association_name)
       raise ArgumentError, "No association #{@association_name} on #{@model}"
     end
+  end
+
+  def policy_klass
+    @policy_klass ||= "#{policy.classify}Policy::Scope".constantize
   end
 
   def preload_association(records)


### PR DESCRIPTION
# What

[RFD](https://www.notion.so/kitsu/GraphQL-Batch-Loading-query-scopes-Pundit-Authentication-f9774179563f422eaa7e03f52ae9c220)

WIP: querying afterwards, which can technically be done with through a `.then` promise. Deciding if we want the AssociationLoader to handle this also.

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
