### PR TITLE
Episodic - update after_save for episode_length change

### DIFF
--- a/app/models/concerns/episodic.rb
+++ b/app/models/concerns/episodic.rb
@@ -40,7 +40,7 @@ module Episodic
 
     after_save do
       if saved_change_to_episode_length?
-        episodes.where(length: nil).update_all(length: episode_length)
+        episodes.where(length: nil).or(episodes.where(length: 0)).update_all(length: episode_length)
       end
     end
   end


### PR DESCRIPTION
# What

Fix the Episodic concern that `after_save` should check if episode_length has changed and update any episodes that are `nil` OR `0`.

# Why

We have a ton of episodes that are 0 and can/should have a proper episode length. 

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
