### PR TITLE
add migration to backfill all episodes with 0 length

### DIFF
--- a/db/migrate/20200603235008_fill_zero_length_on_episodes.rb
+++ b/db/migrate/20200603235008_fill_zero_length_on_episodes.rb
@@ -1,0 +1,7 @@
+class FillZeroLengthOnEpisodes < ActiveRecord::Migration[5.1]
+  def change
+    Episode.where(length: 0).update_all(<<-SQL.squish)
+      length = (SELECT episode_length FROM anime where id = episodes.media_id)
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190603133124) do
+ActiveRecord::Schema.define(version: 20200603235008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
# What

Backfill all the episodes that are 0 with their actual length. PR https://github.com/hummingbird-me/kitsu-server/pull/671 will do it for all future updates.

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
