### PR TITLE
validate media reaction is not blank and strip

### DIFF
--- a/app/models/media_reaction.rb
+++ b/app/models/media_reaction.rb
@@ -53,7 +53,7 @@ class MediaReaction < ApplicationRecord
 
   validates :media_id, uniqueness: { scope: %i[user_id media_type] }, unless: :deleted?
   validates :media, polymorphism: { type: Media }
-  validates :reaction, length: { maximum: 140 }, allow_nil: false
+  validates :reaction, length: { maximum: 140 }, allow_blank: false
 
   resourcify
 
@@ -87,5 +87,9 @@ class MediaReaction < ApplicationRecord
 
   def deleted?
     deleted_at.present?
+  end
+
+  def reaction=(value)
+    super(value&.strip)
   end
 end

--- a/spec/models/media_reaction_spec.rb
+++ b/spec/models/media_reaction_spec.rb
@@ -45,4 +45,7 @@ RSpec.describe MediaReaction, type: :model do
 
   it { should belong_to(:user) }
   it { should belong_to(:library_entry) }
+
+  it { should validate_length_of(:reaction).is_at_most(140) }
+  it { should_not allow_value('').for(:reaction) }
 end


### PR DESCRIPTION
# What

Fix Media Reactions allowing empty reactions (" ") to be saved. Added new validation to check that string is not blank and sanitize (strip) value of all extra whitespaces.

# Why

Media Reactions should not be blank. We had nil checks before this also.

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
