### PR TITLE
Update connections to use AssociationLoader scope

### DIFF
--- a/app/graphql/types/category.rb
+++ b/app/graphql/types/category.rb
@@ -38,6 +38,6 @@ class Types::Category < Types::BaseObject
     description: 'The child categories.'
 
   def children
-    AssociationLoader.for(object.class, :children).load(object)
+    AssociationLoader.for(object.class, :children, policy: :category).scope(object)
   end
 end

--- a/app/graphql/types/episodic_interface.rb
+++ b/app/graphql/types/episodic_interface.rb
@@ -23,7 +23,7 @@ module Types::EpisodicInterface
     if number
       object.episodes.where(number: number)
     else
-      AssociationLoader.for(Anime, :episodes).load(object).then(&:to_a)
+      AssociationLoader.for(Anime, :episodes).scope(object).then(&:to_a)
     end
   end
 end

--- a/app/graphql/types/media.rb
+++ b/app/graphql/types/media.rb
@@ -104,7 +104,7 @@ module Types::Media
     description: 'The characters who starred in this media'
 
   def characters
-    AssociationLoader.for(object.class, :characters).load(object)
+    AssociationLoader.for(object.class, :characters).scope(object)
   end
 
   field :staff, Types::MediaStaff.connection_type,
@@ -112,7 +112,7 @@ module Types::Media
     description: 'The staff members who worked on this media'
 
   def staff
-    AssociationLoader.for(object.class, :staff).load(object)
+    AssociationLoader.for(object.class, :staff, policy: :media_staff).scope(object)
   end
 
   field :productions, Types::MediaProduction.connection_type,
@@ -120,7 +120,7 @@ module Types::Media
     description: 'The companies which helped to produce this media'
 
   def productions
-    AssociationLoader.for(object.class, :productions).load(object)
+    AssociationLoader.for(object.class, :productions, policy: :media_production).scope(object)
   end
 
   field :quotes, Types::Quote.connection_type,
@@ -128,7 +128,7 @@ module Types::Media
     description: 'A list of quotes from this media'
 
   def quotes
-    AssociationLoader.for(object.class, :quotes).load(object).then(&:to_a)
+    AssociationLoader.for(object.class, :quotes).scope(object).then(&:to_a)
   end
 
   field :categories, Types::Category.connection_type,
@@ -136,6 +136,6 @@ module Types::Media
     description: 'A list of categories for this media'
 
   def categories
-    AssociationLoader.for(object.class, :categories).load(object)
+    AssociationLoader.for(object.class, :categories).scope(object)
   end
 end

--- a/app/graphql/types/quote.rb
+++ b/app/graphql/types/quote.rb
@@ -13,6 +13,6 @@ class Types::Quote < Types::BaseObject
     description: 'The lines of the quote'
 
   def lines
-    AssociationLoader.for(Quote, :lines).load(object).then(&:to_a)
+    AssociationLoader.for(Quote, :lines, policy: :quote_line).scope(object).then(&:to_a)
   end
 end

--- a/app/graphql/types/quote_line.rb
+++ b/app/graphql/types/quote_line.rb
@@ -13,7 +13,7 @@ class Types::QuoteLine < Types::BaseObject
     description: 'The character who said this line'
 
   def character
-    AssociationLoader.for(QuoteLine, :character).load(object)
+    AssociationLoader.for(QuoteLine, :character).scope(object)
   end
 
   field :content, String,

--- a/app/policies/quote_line_policy.rb
+++ b/app/policies/quote_line_policy.rb
@@ -1,0 +1,1 @@
+class QuoteLinePolicy < ApplicationPolicy; end


### PR DESCRIPTION
# What
AssociationLoader only has `scope` as a public method. `load` should not be used directly.

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
