### PR TITLE
GraphQL - move all enums to subfolder

### DIFF
--- a/app/graphql/inputs/anime_create_input.rb
+++ b/app/graphql/inputs/anime_create_input.rb
@@ -1,7 +1,7 @@
 class Inputs::AnimeCreateInput < Inputs::BaseInputObject
   argument :titles, Inputs::TitlesListInput, required: true
   argument :synopsis, Types::Map, required: true
-  argument :age_rating, Types::AgeRating, required: false
+  argument :age_rating, Types::Enum::AgeRating, required: false
   argument :age_rating_guide, String, required: false
   argument :tba, String, required: false
   argument :start_date, Types::Date, required: false

--- a/app/graphql/inputs/anime_update_input.rb
+++ b/app/graphql/inputs/anime_update_input.rb
@@ -1,7 +1,7 @@
 class Inputs::AnimeUpdateInput < Inputs::BaseInputObject
   argument :titles, Inputs::TitlesListInput, required: false
   argument :synopsis, Types::Map, required: false
-  argument :age_rating, Types::AgeRating, required: false
+  argument :age_rating, Types::Enum::AgeRating, required: false
   argument :age_rating_guide, String, required: false
   argument :tba, String, required: false
   argument :start_date, Types::Date, required: false

--- a/app/graphql/mutations/pro/subscribe_with_stripe.rb
+++ b/app/graphql/mutations/pro/subscribe_with_stripe.rb
@@ -1,7 +1,7 @@
 class Mutations::Pro::SubscribeWithStripe < Mutations::BaseMutation
   behind_feature_flag :pro_subscriptions
 
-  argument :tier, Types::ProTier,
+  argument :tier, Types::Enum::ProTier,
     required: true,
     description: 'The tier to subscribe to'
   argument :token, String,

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,2 +1,0 @@
-class Types::BaseEnum < GraphQL::Schema::Enum
-end

--- a/app/graphql/types/enum/age_rating.rb
+++ b/app/graphql/types/enum/age_rating.rb
@@ -1,4 +1,4 @@
-class Types::AgeRating < Types::BaseEnum
+class Types::Enum::AgeRating < Types::Enum::Base
   value 'G', 'Acceptable for all ages'
   value 'PG', 'Parental guidance suggested; should be safe for preteens and older'
   value 'R', 'Possible lewd or intense themes; should be safe for teens and older'

--- a/app/graphql/types/enum/base.rb
+++ b/app/graphql/types/enum/base.rb
@@ -1,0 +1,2 @@
+class Types::Enum::Base < GraphQL::Schema::Enum
+end

--- a/app/graphql/types/enum/character_role.rb
+++ b/app/graphql/types/enum/character_role.rb
@@ -1,4 +1,4 @@
-class Types::CharacterRole < Types::BaseEnum
+class Types::Enum::CharacterRole < Types::Enum::Base
   value 'MAIN', 'A character who appears throughout a series and is a focal point of the media',
     value: 'main'
   value 'RECURRING', 'A character who appears in multiple episodes but is not a main character',

--- a/app/graphql/types/enum/pro_tier.rb
+++ b/app/graphql/types/enum/pro_tier.rb
@@ -1,4 +1,4 @@
-class Types::ProTier < Types::BaseEnum
+class Types::Enum::ProTier < Types::Enum::Base
   value 'AO_PRO', 'Aozora Pro (only hides ads)',
     deprecation_reason: 'No longer for sale',
     value: 'ao_pro'

--- a/app/graphql/types/enum/recurring_billing_service.rb
+++ b/app/graphql/types/enum/recurring_billing_service.rb
@@ -1,4 +1,4 @@
-class Types::RecurringBillingService < Types::BaseEnum
+class Types::Enum::RecurringBillingService < Types::Enum::Base
   value 'STRIPE', 'Bill a credit card via Stripe', value: 'stripe'
   value 'PAYPAL', 'Bill a PayPal account', value: 'paypal'
   value 'APPLE', 'Billed through Apple In-App Subscription', value: 'apple_ios'

--- a/app/graphql/types/enum/release_season.rb
+++ b/app/graphql/types/enum/release_season.rb
@@ -1,4 +1,4 @@
-class Types::ReleaseSeason < Types::BaseEnum
+class Types::Enum::ReleaseSeason < Types::Enum::Base
   value 'WINTER', 'Released during the Winter season', value: :winter
   value 'SPRING', 'Released during the Spring season', value: :spring
   value 'SUMMER', 'Released during the Summer season', value: :summer

--- a/app/graphql/types/enum/release_status.rb
+++ b/app/graphql/types/enum/release_status.rb
@@ -1,4 +1,4 @@
-class Types::ReleaseStatus < Types::BaseEnum
+class Types::Enum::ReleaseStatus < Types::Enum::Base
   value 'TBA', 'The release date has not been announced yet', value: :tba
   value 'FINISHED', 'This media is no longer releasing', value: :finished
   value 'CURRENT', 'This media is currently releasing', value: :current

--- a/app/graphql/types/media.rb
+++ b/app/graphql/types/media.rb
@@ -36,7 +36,7 @@ module Types::Media
   end
 
   # Age Rating
-  field :age_rating, Types::AgeRating,
+  field :age_rating, Types::Enum::AgeRating,
     null: true,
     description: 'The recommended minimum age group for this media'
 
@@ -62,11 +62,11 @@ module Types::Media
     null: true,
     description: 'The time of the next release of this media'
 
-  field :status, Types::ReleaseStatus,
+  field :status, Types::Enum::ReleaseStatus,
     null: false,
     description: 'The current releasing status of this media'
 
-  field :season, Types::ReleaseSeason,
+  field :season, Types::Enum::ReleaseSeason,
     null: true,
     description: 'The season this was released in'
 

--- a/app/graphql/types/media_character.rb
+++ b/app/graphql/types/media_character.rb
@@ -4,7 +4,7 @@ class Types::MediaCharacter < Types::BaseObject
   # Identifiers
   field :id, ID, null: false
 
-  field :role, Types::CharacterRole,
+  field :role, Types::Enum::CharacterRole,
     null: false,
     description: 'The role this character had in the media'
 

--- a/app/graphql/types/pro_subscription.rb
+++ b/app/graphql/types/pro_subscription.rb
@@ -5,11 +5,11 @@ class Types::ProSubscription < Types::BaseObject
     null: false,
     description: 'The account which is subscribed to Pro benefits'
 
-  field :tier, Types::ProTier,
+  field :tier, Types::Enum::ProTier,
     null: false,
     description: 'The tier of Pro the account is subscribed to'
 
-  field :billing_service, Types::RecurringBillingService,
+  field :billing_service, Types::Enum::RecurringBillingService,
     null: false,
     description: 'The billing service used for this subscription'
 end

--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -36,7 +36,7 @@ class Types::Profile < Types::BaseObject
     null: true,
     description: 'The user-provided (unsanitized) string used to identify the role of the waifu'
 
-  field :pro_tier, Types::ProTier,
+  field :pro_tier, Types::Enum::ProTier,
     null: true,
     description: 'The level of Pro this user currently has'
 


### PR DESCRIPTION
# What

Move all enums into a subfolder.

# Why

This is to better separate our data, and also make it clear what the specific type is. Our `/types` folder was getting way to cluttered and this is a way to start cleaning it up.

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
