### PR TITLE
banned users cannot follow other users anymore

### DIFF
--- a/app/policies/follow_policy.rb
+++ b/app/policies/follow_policy.rb
@@ -13,6 +13,7 @@ class FollowPolicy < ApplicationPolicy
   # Override to user follower instead of user
   def is_owner? # rubocop:disable Style/PredicateName
     return false unless user && record.follower_id == user.id
+    return false if user.has_role?(:banned)
     return false if record.follower_id_was && record.follower_id_was != user.id
     true
   end

--- a/app/policies/follow_policy.rb
+++ b/app/policies/follow_policy.rb
@@ -1,6 +1,6 @@
 class FollowPolicy < ApplicationPolicy
   def create?
-    is_owner?
+    is_owner? && !user.has_role?(:banned)
   end
   alias_method :update?, :create?
   alias_method :destroy?, :create?
@@ -13,8 +13,8 @@ class FollowPolicy < ApplicationPolicy
   # Override to user follower instead of user
   def is_owner? # rubocop:disable Style/PredicateName
     return false unless user && record.follower_id == user.id
-    return false if user.has_role?(:banned)
     return false if record.follower_id_was && record.follower_id_was != user.id
+
     true
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -115,6 +115,10 @@ FactoryBot.define do
       after(:create) { |user| user.add_role(:admin, Anime) }
     end
 
+    trait :banned do
+      after(:create) { |user| user.add_role(:banned) }
+    end
+
     trait :unregistered do
       status { :unregistered }
       password { nil }

--- a/spec/policies/follow_policy_spec.rb
+++ b/spec/policies/follow_policy_spec.rb
@@ -4,9 +4,14 @@ RSpec.describe FollowPolicy do
   let(:follower) { token_for create(:user) }
   let(:following) { token_for create(:user) }
   let(:other) { token_for build(:user) }
+  let(:banned_user) { token_for create(:user, :banned) }
   let(:follow) do
     build(:follow, follower: follower.resource_owner, followed: following.resource_owner)
   end
+  let(:banned_follow) do
+    build(:follow, follower: banned_user.resource_owner, followed: following.resource_owner)
+  end
+
   subject { described_class }
 
   permissions :update? do
@@ -14,5 +19,6 @@ RSpec.describe FollowPolicy do
     it('should not allow the followed') { should_not permit(following, follow) }
     it('should not allow users') { should_not permit(other, follow) }
     it('should not allow anons') { should_not permit(nil, follow) }
+    it('should not allow banned users') { should_not permit(banned_user, banned_follow) }
   end
 end


### PR DESCRIPTION
# What

If a user is banned, they are not allowed to follow other users anymore.

# Why

They shouldn't have the capabilities to interact with anyone anymore.

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
