### PR TITLE
GraphQL - add basic search for anime and manga titles

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -34,7 +34,8 @@ class Types::QueryType < Types::BaseObject
   end
 
   def search_anime_by_title(title:)
-    AlgoliaMediaIndex.search(title, filters: 'kind:anime')
+    service = AlgoliaGraphqlSearchService.new(::Anime, context[:token])
+    service.search(title, filters: 'kind:anime')
   end
 
   field :manga, Types::Manga.connection_type, null: false do
@@ -72,7 +73,8 @@ class Types::QueryType < Types::BaseObject
   end
 
   def search_manga_by_title(title:)
-    AlgoliaMediaIndex.search(title, filters: 'kind:manga')
+    service = AlgoliaGraphqlSearchService.new(::Manga, context[:token])
+    service.search(title, filters: 'kind:manga')
   end
 
   field :search_media_by_title, Types::Interface::Media.connection_type, null: false do
@@ -84,7 +86,9 @@ class Types::QueryType < Types::BaseObject
   end
 
   def search_media_by_title(title:)
-    AlgoliaMediaIndex.search(title)
+    # Both anime and manga will get the same AlgoliaMediaIndex
+    service = AlgoliaGraphqlSearchService.new(::Anime, context[:token])
+    service.search(title)
   end
 
   field :global_trending, Types::Interface::Media.connection_type, null: false do

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -75,7 +75,7 @@ class Types::QueryType < Types::BaseObject
     AlgoliaMediaIndex.search(title, filters: 'kind:manga')
   end
 
-  field :search_media_by_title, Types::Media.connection_type, null: false do
+  field :search_media_by_title, Types::Interface::Media.connection_type, null: false do
     description <<~DESCRIPTION.squish
       Search for any media (Anime, Manga) by title using Algolia.
       The most relevant results will be at the top.

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -25,6 +25,18 @@ class Types::QueryType < Types::BaseObject
     ::Anime.find_by(slug: slug)
   end
 
+  field :search_anime_by_title, Types::Anime.connection_type, null: false do
+    description <<~DESCRIPTION.squish
+      Search for Anime by title using Algolia.
+      The most relevant results will be at the top.
+    DESCRIPTION
+    argument :title, String, required: true
+  end
+
+  def search_anime_by_title(title:)
+    AlgoliaMediaIndex.search(title, filters: 'kind:anime')
+  end
+
   field :manga, Types::Manga.connection_type, null: false do
     description 'All Manga in the Kitsu database'
   end
@@ -49,6 +61,30 @@ class Types::QueryType < Types::BaseObject
 
   def find_manga_by_slug(slug:)
     ::Manga.find_by(slug: slug)
+  end
+
+  field :search_manga_by_title, Types::Manga.connection_type, null: false do
+    description <<~DESCRIPTION.squish
+      Search for Manga by title using Algolia.
+      The most relevant results will be at the top.
+    DESCRIPTION
+    argument :title, String, required: true
+  end
+
+  def search_manga_by_title(title:)
+    AlgoliaMediaIndex.search(title, filters: 'kind:manga')
+  end
+
+  field :search_media_by_title, Types::Media.connection_type, null: false do
+    description <<~DESCRIPTION.squish
+      Search for any media (Anime, Manga) by title using Algolia.
+      The most relevant results will be at the top.
+    DESCRIPTION
+    argument :title, String, required: true
+  end
+
+  def search_media_by_title(title:)
+    AlgoliaMediaIndex.search(title)
   end
 
   field :global_trending, Types::Interface::Media.connection_type, null: false do

--- a/app/services/algolia_graphql_search_service.rb
+++ b/app/services/algolia_graphql_search_service.rb
@@ -1,0 +1,31 @@
+class AlgoliaGraphqlSearchService
+  def initialize(model, token)
+    @model = model
+    @index = model.algolia_index.safe_constantize
+    @token = token
+  end
+
+  def search(query, **opts)
+    opts[:filters] = scoped_filters(opts[:filters])
+
+    @index.search(query, opts)
+  end
+
+  def scope
+    return @scope if @scope
+    policy = Pundit::PolicyFinder.new(@model).policy
+    @scope = policy::AlgoliaScope.new(@token).resolve
+  rescue NameError
+    ''
+  end
+
+  private
+
+  def scoped_filters(filters)
+    return filters if scope.blank?
+    # if there are no filters supplied, just return the scope
+    return scope if filters.blank?
+
+    "#{filters} AND #{scope}"
+  end
+end


### PR DESCRIPTION
# What

Add the basic ability to search for anime/manga through Algolia.

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
