### PR TITLE
fix(algolia): isolate filters of different types for groups

### DIFF
--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -40,7 +40,7 @@ class GroupPolicy < ApplicationPolicy
       group_ids = GroupMember.joins(:group).merge(Group.closed).for_user(user).pluck(:group_id)
       groups = group_ids.map { |id| "id = #{id}" }
       private_groups = [*groups].compact.join(' OR ')
-      public_groups = "privacy:open OR privacy:restricted"
+      public_groups = 'privacy:open OR privacy:restricted'
       visible_groups = groups.empty? ? public_groups : "(#{private_groups}) OR (#{public_groups})"
       see_nsfw? ? visible_groups : "(#{visible_groups}) AND NOT nsfw:true"
     end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -39,8 +39,9 @@ class GroupPolicy < ApplicationPolicy
     def resolve
       group_ids = GroupMember.joins(:group).merge(Group.closed).for_user(user).pluck(:group_id)
       groups = group_ids.map { |id| "id = #{id}" }
-      visible_hidden_groups = groups.empty? ? "" : "(#{[*groups].compact.join(' OR ')}) OR "
-      visible_groups = "#{visible_hidden_groups}(privacy:open OR privacy:restricted)"
+      hidden_groups = [*groups.compact.join(' OR ')]
+      public_groups = "privacy:open OR privacy:restricted"
+      visible_groups = groups.empty? ? public_groups : "(#{hidden_groups}) OR (#{public_groups})"
       see_nsfw? ? visible_groups : "(#{visible_groups}) AND NOT nsfw:true"
     end
   end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -39,7 +39,8 @@ class GroupPolicy < ApplicationPolicy
     def resolve
       group_ids = GroupMember.joins(:group).merge(Group.closed).for_user(user).pluck(:group_id)
       groups = group_ids.map { |id| "id = #{id}" }
-      visible_groups = "(#{[*groups].compact.join(' OR ')}) OR (privacy:open OR privacy:restricted)"
+      visible_hidden_groups = groups.empty? ? "" : "(#{[*groups].compact.join(' OR ')}) OR "
+      visible_groups = "#{visible_hidden_groups}(privacy:open OR privacy:restricted)"
       see_nsfw? ? visible_groups : "(#{visible_groups}) AND NOT nsfw:true"
     end
   end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -39,7 +39,7 @@ class GroupPolicy < ApplicationPolicy
     def resolve
       group_ids = GroupMember.joins(:group).merge(Group.closed).for_user(user).pluck(:group_id)
       groups = group_ids.map { |id| "id = #{id}" }
-      private_groups = [*groups.compact.join(' OR ')]
+      private_groups = [*groups].compact.join(' OR ')
       public_groups = "privacy:open OR privacy:restricted"
       visible_groups = groups.empty? ? public_groups : "(#{private_groups}) OR (#{public_groups})"
       see_nsfw? ? visible_groups : "(#{visible_groups}) AND NOT nsfw:true"

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -39,9 +39,9 @@ class GroupPolicy < ApplicationPolicy
     def resolve
       group_ids = GroupMember.joins(:group).merge(Group.closed).for_user(user).pluck(:group_id)
       groups = group_ids.map { |id| "id = #{id}" }
-      hidden_groups = [*groups.compact.join(' OR ')]
+      private_groups = [*groups.compact.join(' OR ')]
       public_groups = "privacy:open OR privacy:restricted"
-      visible_groups = groups.empty? ? public_groups : "(#{hidden_groups}) OR (#{public_groups})"
+      visible_groups = groups.empty? ? public_groups : "(#{private_groups}) OR (#{public_groups})"
       see_nsfw? ? visible_groups : "(#{visible_groups}) AND NOT nsfw:true"
     end
   end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -39,7 +39,7 @@ class GroupPolicy < ApplicationPolicy
     def resolve
       group_ids = GroupMember.joins(:group).merge(Group.closed).for_user(user).pluck(:group_id)
       groups = group_ids.map { |id| "id = #{id}" }
-      visible_groups = [*groups, 'privacy:open', 'privacy:restricted'].compact.join(' OR ')
+      visible_groups = "(#{[*groups].compact.join(' OR ')}) OR (privacy:open OR privacy:restricted)"
       see_nsfw? ? visible_groups : "(#{visible_groups}) AND NOT nsfw:true"
     end
   end


### PR DESCRIPTION
# Why

ID and Privacy are different types and can't be mixed in the same OR group. This isolates them into separate groups. This was causing the query for logged in users to error and return no results.

# Output

- `privacy:open OR privacy:restricted`
- `(privacy:open OR privacy:restricted) AND NOT nsfw:true`
- `(id = 1 OR id = 2 OR id = 3) OR (privacy:open OR privacy:restricted)`
- `((id = 1 OR id = 2 OR id = 3) OR (privacy:open OR privacy:restricted)) AND NOT nsfw:true`