### PR TITLE
fix(concerns): allow en to pass English title validation

### DIFF
--- a/app/models/concerns/titleable.rb
+++ b/app/models/concerns/titleable.rb
@@ -19,7 +19,7 @@ module Titleable
   private
 
   def has_english_title?
-    titles.keys.any? { |k| k.end_with?('_en') || k.start_with?('en_') }
+    titles.keys.any? { |k| k.start_with?('en') }
   end
 
   def has_english_title


### PR DESCRIPTION
<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What

`en`, `en_us`, `en_jp`, `en_kr` pass validation

Removed `ends_with('en')` as that will never be true. ``EN` is not a **ISO 3166** country code and would not be an English title if a country existed.

# Why

`en` currently does not pass validation, preventing it being used as the canonical key for Korean and Chinese media without a Romanised title, where they instead need to add a region-specific English title (e.g `en_us`) as canonical.

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [ ] Tests have been added to cover the new code
