### PR TITLE
Generate blurhashes for images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,12 @@ gem 'rolify'
 # Attachments
 gem 'apollo_upload_server'
 gem 'aws-sdk', '< 3.0'
+# released version of blurhash has too-narrow ffi version
+gem 'blurhash', github: 'gargron/blurhash'
 gem 'delayed_paperclip'
 gem 'image_optim', require: false
 gem 'image_optim_pack', require: false
+gem 'mini_magick'
 gem 'paperclip', '~> 5.0'
 gem 'paperclip-meta'
 gem 'paperclip-optimizer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,13 @@ GIT
       railties (>= 3.1)
 
 GIT
+  remote: https://github.com/gargron/blurhash.git
+  revision: 9084bfa64fbadbaff1ba95c52bda3153efcb3f84
+  specs:
+    blurhash (0.1.4)
+      ffi (~> 1.10)
+
+GIT
   remote: https://github.com/hummingbird-me/pundit-resources.git
   revision: a93c8708a697591bbbf9cac2a5d7a6695d769e61
   specs:
@@ -361,6 +368,7 @@ GEM
     mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
     mini_histogram (0.1.3)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
@@ -670,6 +678,7 @@ DEPENDENCIES
   aws-sdk (< 3.0)
   bcrypt
   benchmark-ips
+  blurhash!
   chewy
   connection_pool
   counter_culture
@@ -708,6 +717,7 @@ DEPENDENCIES
   librato-rails
   lograge
   mechanize
+  mini_magick
   mongo
   nokogiri (~> 1.10.8)
   oauth2!

--- a/app/graphql/types/image.rb
+++ b/app/graphql/types/image.rb
@@ -3,12 +3,6 @@ class Types::Image < Types::BaseObject
     null: false,
     description: 'The original image'
 
-  field :views, [Types::ImageView],
-    null: false,
-    description: 'The various generated views of this image' do
-      argument :names, [String], required: false
-    end
-
   def original
     {
       name: 'original',
@@ -17,6 +11,12 @@ class Types::Image < Types::BaseObject
       height: object.height(:original)
     }
   end
+
+  field :views, [Types::ImageView],
+    null: false,
+    description: 'The various generated views of this image' do
+      argument :names, [String], required: false
+    end
 
   def views(names: object.styles.keys)
     styles = object.styles.keys
@@ -29,4 +29,8 @@ class Types::Image < Types::BaseObject
       }
     end
   end
+
+  field :blurhash, String,
+    null: true,
+    description: 'A blurhash-encoded version of this image'
 end

--- a/app/graphql/types/image.rb
+++ b/app/graphql/types/image.rb
@@ -12,11 +12,10 @@ class Types::Image < Types::BaseObject
     }
   end
 
-  field :views, [Types::ImageView],
-    null: false,
-    description: 'The various generated views of this image' do
-      argument :names, [String], required: false
-    end
+  field :views, [Types::ImageView], null: false do
+    description 'The various generated views of this image'
+    argument :names, [String], required: false
+  end
 
   def views(names: object.styles.keys)
     styles = object.styles.keys
@@ -30,7 +29,7 @@ class Types::Image < Types::BaseObject
     end
   end
 
-  field :blurhash, String,
-    null: true,
-    description: 'A blurhash-encoded version of this image'
+  field :blurhash, String, null: true do
+    description 'A blurhash-encoded version of this image'
+  end
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -44,8 +44,12 @@ module PaperclipBlurhash
   def populate_meta(queue)
     meta = super(queue)
 
+    original = queue[:original]
+    return meta unless original.is_a?(String) || original.respond_to?(:path)
+    path = original.respond_to?(:path) ? original.path : original
+
     # Scale down so we don't have as much data to fuck with
-    image = MiniMagick::Image.open(queue[:original])
+    image = MiniMagick::Image.open(path)
     image.resize '600x600>'
     pixels = image.get_pixels.flatten
 

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -30,6 +30,43 @@ module IgnoreOctetStream
   end
 end
 
+module PaperclipBlurhash
+  def blurhash
+    return unless instance.respond_to?(:"#{name}_meta") && instance_read(:meta)
+
+    if (meta = meta_decode(instance_read(:meta)))
+      meta[:blurhash]
+    end
+  end
+
+  private
+
+  def populate_meta(queue)
+    meta = super(queue)
+
+    # Scale down so we don't have as much data to fuck with
+    image = MiniMagick::Image.open(queue[:original])
+    image.resize '600x600>'
+    pixels = image.get_pixels.flatten
+
+    # Blurhash looks like shit below 3 or above 6 in any dimension
+    blurhash_size = image.dimensions.map do |x|
+      (x.to_f / 100).floor.clamp(3, 6)
+    end
+
+    meta[:blurhash] = Blurhash.encode(
+      image.width,
+      image.height,
+      pixels,
+      x_comp: blurhash_size[0],
+      y_comp: blurhash_size[1]
+    )
+
+    meta
+  end
+end
+
+Paperclip::Attachment.prepend(PaperclipBlurhash)
 Paperclip::MediaTypeSpoofDetector.prepend(IgnoreOctetStream::SpoofDetector)
 Paperclip::UriAdapter.prepend(IgnoreOctetStream::Download)
 


### PR DESCRIPTION
# What

Generate a blurhash for images! [Blurhash](https://blurha.sh) is a way of encoding a pretty blurred version of an image in a tiny string to display while you're loading the full thing!

I've hooked it up with MiniMagick (an ImageMagick wrapper) to load and prescale the image data, and linked it up with Paperclip-Meta to store it in the existing meta column.

# Why

Because it's pretty and we have a _lot_ of images that could benefit from this!

I chose MiniMagick over RMagick because it doesn't use a huge (and frankly super buggy) native extension, instead shelling out to ImageMagick or GraphicsMagick.

I'll also mention: I haven't added any tests for this because I'm intending for this to be a temporary solution until we have [Clerk](https://github.com/hummingbird-me/clerk) handling files.