### PR TITLE
Improve Rails Admin experience

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,4 +1,7 @@
 require Rails.root.join('lib/rails_admin/config/fields/types/citext')
+require Rails.root.join('lib/rails_admin/config/fields/types/localized_string')
+require Rails.root.join('lib/rails_admin/config/fields/types/localized_text')
+require Rails.root.join('lib/rails_admin/config/fields/types/string_list')
 
 RailsAdmin::ApplicationHelper.module_exec do
   def edit_user_link
@@ -63,11 +66,9 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   # Anime
   config.model 'Anime' do
     field :id
-    field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    field :abbreviated_titles, :serialized do
-      html_attributes rows: '6', cols: '70'
-    end
-    field(:description, :serialized) { html_attributes rows: '6', cols: '70' }
+    field :titles, :localized_string
+    field :abbreviated_titles, :string_list
+    field :description, :localized_text
     fields :canonical_title, :slug, :subtype, :poster_image, :cover_image,
       :age_rating, :age_rating_guide, :episode_count, :episode_count_guess
     include_all_fields
@@ -83,11 +84,9 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   # Manga
   config.model 'Manga' do
     field :id
-    field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    field :abbreviated_titles, :serialized do
-      html_attributes rows: '6', cols: '70'
-    end
-    field(:description, :serialized) { html_attributes rows: '6', cols: '70' }
+    field :titles, :localized_string
+    field :abbreviated_titles, :string_list
+    field :description, :localized_text
     fields :canonical_title, :slug, :subtype, :poster_image, :cover_image,
       :age_rating, :age_rating_guide, :chapter_count, :chapter_count_guess, :volume_count
     include_all_fields
@@ -101,8 +100,8 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   config.model 'Chapter' do
     parent Manga
     fields :id, :manga
-    field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    field(:description, :serialized) { html_attributes rows: '6', cols: '70' }
+    field :titles, :localized_string
+    field :description, :localized_text
     fields :canonical_title, :number, :published, :volume_number,
       :length, :thumbnail
     include_all_fields
@@ -111,11 +110,9 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
   # Drama
   config.model 'Drama' do
     field :id
-    field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    field :abbreviated_titles, :serialized do
-      html_attributes rows: '6', cols: '70'
-    end
-    field(:description, :serialized) { html_attributes rows: '6', cols: '70' }
+    field :titles, :localized_string
+    field :abbreviated_titles, :string_list
+    field :description, :localized_text
     fields :canonical_title, :slug, :subtype, :poster_image,
       :cover_image, :age_rating, :age_rating_guide
     include_all_fields
@@ -223,8 +220,8 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
 
   config.model 'Episode' do
     fields :id, :media
-    field(:titles, :serialized) { html_attributes rows: '6', cols: '70' }
-    field(:description, :serialized) { html_attributes rows: '6', cols: '70' }
+    field :titles, :localized_string
+    field :description, :localized_text
     fields :canonical_title, :number, :relative_number, :season_number, :airdate,
       :length, :thumbnail
     include_all_fields
@@ -259,9 +256,9 @@ RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
 
   config.model 'Character' do
     field :id
-    field(:names, :serialized) { html_attributes rows: '6', cols: '70' }
-    field(:other_names, :serialized) { html_attributes rows: '6', cols: '70' }
-    field(:description, :serialized) { html_attributes rows: '6', cols: '70' }
+    field :names, :localized_string
+    field :other_names, :string_list
+    field :description, :localized_text
     fields :image, :slug, :canonical_name
     include_all_fields
   end

--- a/lib/rails_admin/config/fields/types/localized_string.rb
+++ b/lib/rails_admin/config/fields/types/localized_string.rb
@@ -1,0 +1,45 @@
+require 'rails_admin/config/fields/types/text'
+
+module RailsAdmin
+  module Config
+    module Fields
+      module Types
+        class LocalizedString < RailsAdmin::Config::Fields::Types::Text
+          # Register field type for the type loader
+          RailsAdmin::Config::Fields::Types.register(self)
+
+          register_instance_option :html_attributes do
+            {
+              required: required?,
+              cols: '70',
+              rows: '6'
+            }
+          end
+
+          def form_default_value
+            default_value if bindings[:object].new_record?
+          end
+
+          def formatted_value
+            return nil if value.blank?
+            value.map { |(key, value)| "#{key}: #{value}" }.join("\n")
+          end
+
+          def parse_value(value)
+            return if value.blank?
+
+            value.each_line
+                 .map { |line| line.split(':').map(&:strip) }
+                 .filter { |line| line.count == 2 }
+                 .to_h
+          end
+
+          def parse_input(params)
+            return unless params[name].is_a?(::String)
+            params[name] = parse_value(params[name])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_admin/config/fields/types/localized_text.rb
+++ b/lib/rails_admin/config/fields/types/localized_text.rb
@@ -1,0 +1,50 @@
+require 'rails_admin/config/fields/types/text'
+
+module RailsAdmin
+  module Config
+    module Fields
+      module Types
+        class LocalizedText < RailsAdmin::Config::Fields::Types::Text
+          # Register field type for the type loader
+          RailsAdmin::Config::Fields::Types.register(self)
+
+          register_instance_option :html_attributes do
+            {
+              required: required?,
+              cols: '70',
+              rows: '10'
+            }
+          end
+
+          def form_default_value
+            default_value if bindings[:object].new_record?
+          end
+
+          def formatted_value
+            return nil if value.blank?
+            value.map { |(key, value)| "==#{key}\n#{value}" }.join("\n\n")
+          end
+
+          def parse_value(value)
+            return if value.blank?
+
+            section = 'en'
+            value.each_line.each_with_object({ 'en' => '' }) do |line, obj|
+              if line.start_with?('==')
+                section = line[2..-1].strip
+                obj[section] = ''
+              else
+                obj[section] << line
+              end
+            end
+          end
+
+          def parse_input(params)
+            return unless params[name].is_a?(::String)
+            params[name] = parse_value(params[name])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_admin/config/fields/types/string_list.rb
+++ b/lib/rails_admin/config/fields/types/string_list.rb
@@ -1,0 +1,42 @@
+require 'rails_admin/config/fields/types/text'
+
+module RailsAdmin
+  module Config
+    module Fields
+      module Types
+        class LocalizedString < RailsAdmin::Config::Fields::Types::Text
+          # Register field type for the type loader
+          RailsAdmin::Config::Fields::Types.register(self)
+
+          register_instance_option :html_attributes do
+            {
+              required: required?,
+              cols: '70',
+              rows: '6'
+            }
+          end
+
+          def form_default_value
+            default_value if bindings[:object].new_record?
+          end
+
+          def formatted_value
+            return nil if value.blank?
+            value.join("\n")
+          end
+
+          def parse_value(value)
+            return if value.blank?
+
+            value.each_line.to_a
+          end
+
+          def parse_input(params)
+            return unless params[name].is_a?(::String)
+            params[name] = parse_value(params[name])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What

Create three new inputs for Rails Admin:

### LocalizedString
A set of single-line strings for locales

### LocalizedText
A set of multi-line strings for locales

### StringList
A list of single-line strings

# Why

Mods are currently forced to know YAML and there's no good error messages, which is stupid.  This simplifies the syntax and makes it so mods don't need to really know YAML
