### PR TITLE
fix: correct class name for custom string_list type

### DIFF
--- a/lib/rails_admin/config/fields/types/string_list.rb
+++ b/lib/rails_admin/config/fields/types/string_list.rb
@@ -4,7 +4,7 @@ module RailsAdmin
   module Config
     module Fields
       module Types
-        class LocalizedString < RailsAdmin::Config::Fields::Types::Text
+        class StringList < RailsAdmin::Config::Fields::Types::Text
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types.register(self)
 


### PR DESCRIPTION
Rails Admin can't find the `string_list` type because `localized_string` is defined twice instead.

#792 