### PR TITLE
Add units to GraphQL

### DIFF
--- a/app/graphql/types/chapter.rb
+++ b/app/graphql/types/chapter.rb
@@ -1,40 +1,12 @@
 class Types::Chapter < Types::BaseObject
-  include HasLocalizedField
+  implements Types::Interface::Unit
 
-  description 'A single chapter part of a volume.'
+  description 'A single chapter of a manga'
 
-  field :id, ID, null: false
-
-  field :titles, Types::TitlesList,
-    null: false,
-    description: 'The titles for this chapter in various locales'
-
-  def titles
-    {
-      localized: object.titles,
-      canonical: object.canonical_title
-    }
-  end
-
-  field :number, Integer,
-    null: false,
-    description: 'The number of pages in this chapter.'
-
-  field :published, GraphQL::Types::ISO8601Date,
+  field :released_at, GraphQL::Types::ISO8601Date,
+    method: :published,
     null: true,
-    description: 'The date when this chapter was released.'
-
-  # NOTE: once synopsis changes have been merged
-  # localized_field :description,
-  #   description: 'A brief summary or description of the chapter.'
-
-  field :thumbnail, Types::Image,
-    null: true,
-    description: 'A thumbnail image for the chapter.'
-
-  field :volume_number, Integer,
-    null: true,
-    description: 'The volume number this chapter is in.'
+    description: 'When this chapter was released'
 
   field :volume, Types::Volume,
     null: true,

--- a/app/graphql/types/episode.rb
+++ b/app/graphql/types/episode.rb
@@ -1,38 +1,18 @@
 class Types::Episode < Types::BaseObject
-  include HasLocalizedField
+  implements Types::Interface::Unit
 
   description 'An Episode of a Media'
 
-  field :id, ID, null: false
-
-  field :titles, Types::TitlesList,
-    null: false,
-    description: 'The titles for this episode in various locales'
-
-  def titles
-    {
-      localized: object.titles,
-      canonical: object.canonical_title
-    }
-  end
-
-  localized_field :description,
-    description: 'A brief summary or description of the episode.'
-
-  field :number, Integer,
-    null: false,
-    description: 'The sequence number of this episode in the season'
-
   field :length, Integer,
     null: true,
-    description: 'The length of the Episode in seconds'
+    description: 'The length of the episode in seconds'
 
-  field :aired_at, GraphQL::Types::ISO8601DateTime,
+  field :released_at, GraphQL::Types::ISO8601DateTime,
     null: true,
-    description: 'The time when the episode aired',
+    description: 'When this episode aired',
     method: :airdate
 
-  field :thumbnail, Types::Image,
-    null: true,
-    description: 'A thumbnail image for the episode'
+  field :anime, Types::Anime,
+    null: false,
+    description: 'The anime this episode is in'
 end

--- a/app/graphql/types/interface/unit.rb
+++ b/app/graphql/types/interface/unit.rb
@@ -1,0 +1,30 @@
+module Types::Interface::Unit
+  include Types::Interface::Base
+  include HasLocalizedField
+
+  description 'Media units such as episodes or chapters'
+
+  field :id, ID, null: false
+
+  field :titles, Types::TitlesList,
+    null: false,
+    description: 'The titles for this unit in various locales'
+
+  def titles
+    {
+      localized: object.titles,
+      canonical: object.canonical_title
+    }
+  end
+
+  localized_field :description,
+    description: 'A brief summary or description of the unit'
+
+  field :number, Integer,
+    null: false,
+    description: 'The sequence number of this unit'
+
+  field :thumbnail, Types::Image,
+    null: true,
+    description: 'A thumbnail image for the unit'
+end

--- a/app/graphql/types/library_entry.rb
+++ b/app/graphql/types/library_entry.rb
@@ -11,6 +11,14 @@ class Types::LibraryEntry < Types::BaseObject
     null: false,
     description: 'The media related to this library entry.'
 
+  field :last_unit, Types::Interface::Unit,
+    null: true,
+    description: 'The last unit consumed'
+
+  field :next_unit, Types::Interface::Unit,
+    null: true,
+    description: 'The next unit to be consumed'
+
   field :status, Types::Enum::LibraryEntryStatus,
     null: false,
     description: ''

--- a/app/graphql/types/library_entry.rb
+++ b/app/graphql/types/library_entry.rb
@@ -13,7 +13,8 @@ class Types::LibraryEntry < Types::BaseObject
 
   field :last_unit, Types::Interface::Unit,
     null: true,
-    description: 'The last unit consumed'
+    description: 'The last unit consumed',
+    method: :unit
 
   field :next_unit, Types::Interface::Unit,
     null: true,


### PR DESCRIPTION
# What

We're missing an interface for Units in GraphQL and the corresponding associations on LibraryEntry which power the quick update