### PR TITLE
ci(graphql): upload schema changes on deployments

### DIFF
--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -1,7 +1,7 @@
 name: Apollo Studio Schema Changes
 
 #on: [deployment]
-on: [push,pull_request] # Debug
+on: [pull_request] # Debug
 
 env:
   LOG_LEVEL: warn

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -49,7 +49,7 @@ jobs:
         ruby-version: ${{ matrix.ruby_version }}
 
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node_version }}
 

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -19,17 +19,8 @@ jobs:
     services:
       postgres:
         image: postgres:10-alpine
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: kitsu_test
-        ports:
-          - 5432/tcp
       redis:
         image: redis:alpine
-        ports:
-          - 6379/tcp
 
     steps:
     - name: Checkout Repository

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -1,7 +1,6 @@
 name: Apollo Studio Schema Changes
 
-#on: [deployment]
-on: [pull_request] # Debug
+on: [deployment]
 
 env:
   BUNDLE_GITHUB__HTTPS: true

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -4,6 +4,7 @@ name: Apollo Studio Schema Changes
 on: [pull_request] # Debug
 
 env:
+  BUNDLE_GITHUB__HTTPS: true
   LOG_LEVEL: warn
 
 jobs:
@@ -19,8 +20,17 @@ jobs:
     services:
       postgres:
         image: postgres:10-alpine
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: kitsu_test
+        ports:
+          - 5432/tcp
       redis:
         image: redis:alpine
+        ports:
+          - 6379/tcp
 
     steps:
     - name: Checkout Repository
@@ -53,6 +63,9 @@ jobs:
 
     - name: Dump GraphQL Schema
       run: bin/rails graphql:dump_schema
+      env:
+        DATABASE_URL: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/kitsu_test
+        REDIS_URL: redis://localhost:${{ job.services.redis.ports[6379] }}/1
 
     - name: Upload GraphQL Schema
       run: npx apollo service:push --graph=kitsu --key=${{ secrets.APOLLO_KEY }} --variant=current --localSchemaFile=./schema.graphql

--- a/.github/workflows/deploy-schema.yml
+++ b/.github/workflows/deploy-schema.yml
@@ -1,0 +1,67 @@
+name: Apollo Studio Schema Changes
+
+#on: [deployment]
+on: [push,pull_request] # Debug
+
+env:
+  LOG_LEVEL: warn
+
+jobs:
+  apollo-studio:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node_version: [14]
+        ruby_version: [2.6.x]
+
+    runs-on: ${{ matrix.os }}
+
+    services:
+      postgres:
+        image: postgres:10-alpine
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: kitsu_test
+        ports:
+          - 5432/tcp
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379/tcp
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v1
+
+    - name: Restore Cached Dependencies
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
+
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby_version }}
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node_version }}
+
+    - name: Install Dependencies
+      run: |
+        sudo apt-get -yqq install libpq-dev
+        gem install bundler
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+
+    - name: Dump GraphQL Schema
+      run: bin/rails graphql:dump_schema
+
+    - name: Upload GraphQL Schema
+      run: npx apollo service:push --graph=kitsu --key=${{ secrets.APOLLO_KEY }} --variant=current --localSchemaFile=./schema.graphql

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 ## Environment normalization:
 /.bundle
 /vendor/bundle
+
+## Apollo Studio
+/schema.graphql

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,0 +1,15 @@
+namespace :graphql do
+  task :dump_schema do
+    require 'graphql/rake_task'
+
+    GraphQL::RakeTask.new(
+      load_schema: ->(_task) {
+        require File.expand_path('../../app/graphql/kitsu_schema', __dir__)
+        KitsuSchema
+      },
+      directory: './' # Creates ./schema.graphql
+    )
+
+    Rake::Task['graphql:schema:idl'].invoke
+  end
+end

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,5 +1,5 @@
 namespace :graphql do
-  task :dump_schema do
+  task dump_schema: :environment do
     require 'graphql/rake_task'
 
     GraphQL::RakeTask.new(


### PR DESCRIPTION
Dumps the GraphQL schema and uploads it to Apollo Studio on each deployment.

TODO:
- [x] Add `APOLLO_KEY` to environment variables in Settings
- [x] Switch `on` back to `deployment`
