### PR TITLE
Mod Permissions Revisited

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,7 +42,7 @@ class UsersController < ApplicationController
   end
 
   def alts
-    return render_jsonapi_error(401, 'Not permitted') unless user&.has_role?(:admin, User)
+    return render_jsonapi_error(401, 'Not permitted') unless user&.permissions&.community_mod?
     target_user = User.find(params[:id])
     ModeratorActionLog.generate!(user, 'viewed alts', target_user)
     alts = target_user.alts.map do |(u, weight)|
@@ -57,7 +57,7 @@ class UsersController < ApplicationController
   end
 
   def ban
-    return render_jsonapi_error(401, 'Not permitted') unless user&.has_role?(:admin, User)
+    return render_jsonapi_error(401, 'Not permitted') unless user&.permissions&.community_mod?
     target_user = User.find(params[:id])
     ModeratorActionLog.generate!(user, 'banned', target_user)
     target_user.add_role(:banned)
@@ -65,7 +65,7 @@ class UsersController < ApplicationController
   end
 
   def unban
-    return render_jsonapi_error(401, 'Not permitted') unless user&.has_role?(:admin, User)
+    return render_jsonapi_error(401, 'Not permitted') unless user&.permissions&.community_mod?
     target_user = User.find(params[:id])
     ModeratorActionLog.generate!(user, 'unbanned', target_user)
     target_user.remove_role(:banned)
@@ -73,7 +73,7 @@ class UsersController < ApplicationController
   end
 
   def destroy_content
-    return render_jsonapi_error(401, 'Not permitted') unless user&.has_role?(:admin, User)
+    return render_jsonapi_error(401, 'Not permitted') unless user&.permissions&.community_mod?
     target_user = User.find(params[:id])
     kinds = Array.wrap(params[:kind])
     ModeratorActionLog.generate!(user, "destroyed #{kinds.join(', ')}", target_user)

--- a/app/graphql/types/account.rb
+++ b/app/graphql/types/account.rb
@@ -61,4 +61,9 @@ class Types::Account < Types::BaseObject
   field :country, String,
     null: true,
     description: 'The country this user resides in'
+
+  field :site_permissions, [Types::Enum::SitePermission],
+    null: false,
+    method: :permissions,
+    description: 'The site-wide permissions this user has access to'
 end

--- a/app/graphql/types/enum/site_permission.rb
+++ b/app/graphql/types/enum/site_permission.rb
@@ -1,0 +1,5 @@
+class Types::Enum::SitePermission < Types::Enum::Base
+  value 'ADMIN', 'Administrator/staff member of Kitsu', value: 'admin'
+  value 'COMMUNITY_MOD', 'Moderator of community behavior', value: 'community_mod'
+  value 'DATABASE_MOD', 'Maintainer of the Kitsu media database', value: 'database_mod'
+end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -30,8 +30,8 @@ class Block < ApplicationRecord
   validate :not_blocking_admin
   def not_blocking_admin
     return unless blocked
-    errors.add(:blocked, 'You cannot block admins.') if blocked.has_role?(:admin)
-    errors.add(:blocked, 'You cannot block moderators.') if blocked.title == 'Mod'
+    errors.add(:blocked, 'You cannot block admins.') if blocked.permissions.admin?
+    errors.add(:blocked, 'You cannot block moderators.') if blocked.permissions.community_mod?
   end
 
   validate :not_blocking_self

--- a/app/models/library_entry.rb
+++ b/app/models/library_entry.rb
@@ -73,7 +73,7 @@ class LibraryEntry < ApplicationRecord
     scope = user && !user.sfw_filter? ? all : sfw
 
     return scope.privacy(:public) unless user
-    return scope if user.has_role?(:admin)
+    return scope if user.permissions.admin?
 
     scope.privacy(:public).or(
       where(user_id: user).privacy(:private)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -127,6 +127,7 @@ class User < ApplicationRecord
   enum title_language_preference: %i[canonical romanized localized]
 
   rolify after_add: :update_title, after_remove: :update_title
+  flag :permissions, %i[admin community_mod database_mod]
   has_secure_password validations: false
   update_index('users#user') { self }
   update_algolia('AlgoliaUsersIndex')
@@ -345,15 +346,15 @@ class User < ApplicationRecord
   end
 
   def update_title(_role)
-    if has_role?(:admin)
+    if permissions.admin?
       update(title: 'Staff')
-    elsif has_role?(:admin, Anime) || has_role?(:mod)
+    elsif permissions.database_mod? || permissions.community_mod?
       update(title: 'Mod')
     end
   end
 
   def admin?
-    title == 'Staff' || title == 'Mod'
+    permissions.admin? || permissions.database_mod? || permissions.community_mod?
   end
 
   def profile_feed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,6 +126,7 @@ class User < ApplicationRecord
   enum email_status: %i[email_unconfirmed email_confirmed email_bounced]
   enum title_language_preference: %i[canonical romanized localized]
 
+  rolify
   flag :permissions, %i[admin community_mod database_mod]
   has_secure_password validations: false
   update_index('users#user') { self }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,7 +126,6 @@ class User < ApplicationRecord
   enum email_status: %i[email_unconfirmed email_confirmed email_bounced]
   enum title_language_preference: %i[canonical romanized localized]
 
-  rolify after_add: :update_title, after_remove: :update_title
   flag :permissions, %i[admin community_mod database_mod]
   has_secure_password validations: false
   update_index('users#user') { self }
@@ -345,7 +344,7 @@ class User < ApplicationRecord
     alts.sort_by { |_, v| v }.reverse
   end
 
-  def update_title(_role)
+  def update_title
     if permissions.admin?
       update(title: 'Staff')
     elsif permissions.database_mod? || permissions.community_mod?
@@ -431,6 +430,7 @@ class User < ApplicationRecord
     end
     self.previous_email = nil if confirmed_at_changed?
     self.previous_email = email_was if email_changed?
+    update_title
     update_profile_completed
     update_feed_completed
   end

--- a/app/policies/ama_policy.rb
+++ b/app/policies/ama_policy.rb
@@ -2,11 +2,11 @@ class AMAPolicy < ApplicationPolicy
   administrated_by :community_mod
 
   def update?
-    record.author == user || is_admin?
+    record.author == user || can_administrate?
   end
 
   def destroy?
-    record.author == user || is_admin?
+    record.author == user || can_administrate?
   end
 
   def create?

--- a/app/policies/ama_policy.rb
+++ b/app/policies/ama_policy.rb
@@ -1,4 +1,6 @@
 class AMAPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def update?
     record.author == user || is_admin?
   end
@@ -8,6 +10,6 @@ class AMAPolicy < ApplicationPolicy
   end
 
   def create?
-    is_admin?
+    can_administrate?
   end
 end

--- a/app/policies/anime_casting_policy.rb
+++ b/app/policies/anime_casting_policy.rb
@@ -1,2 +1,3 @@
 class AnimeCastingPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/anime_character_policy.rb
+++ b/app/policies/anime_character_policy.rb
@@ -1,2 +1,3 @@
 class AnimeCharacterPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/anime_media_attribute_policy.rb
+++ b/app/policies/anime_media_attribute_policy.rb
@@ -1,4 +1,6 @@
 class AnimeMediaAttributePolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   def create?
     false
   end

--- a/app/policies/anime_policy.rb
+++ b/app/policies/anime_policy.rb
@@ -1,4 +1,6 @@
 class AnimePolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   class Scope < Scope
     def resolve
       if user && !user.sfw_filter?

--- a/app/policies/anime_production_policy.rb
+++ b/app/policies/anime_production_policy.rb
@@ -1,2 +1,3 @@
 class AnimeProductionPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/anime_staff_policy.rb
+++ b/app/policies/anime_staff_policy.rb
@@ -1,2 +1,3 @@
 class AnimeStaffPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/block_policy.rb
+++ b/app/policies/block_policy.rb
@@ -1,16 +1,18 @@
 class BlockPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def create?
     return false if record == Block
     record.user == user
   end
 
   def destroy?
-    record.try(:user) == user || is_admin?
+    record.try(:user) == user || can_administrate?
   end
 
   class Scope < Scope
     def resolve
-      return scope if is_admin?
+      return scope if can_administrate?
       scope.where(user: user)
     end
   end

--- a/app/policies/casting_policy.rb
+++ b/app/policies/casting_policy.rb
@@ -1,2 +1,3 @@
 class CastingPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -1,4 +1,6 @@
 class CategoryPolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   class Scope < Scope
     def resolve
       return scope if see_nsfw?

--- a/app/policies/chapter_policy.rb
+++ b/app/policies/chapter_policy.rb
@@ -1,2 +1,3 @@
 class ChapterPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/character_policy.rb
+++ b/app/policies/character_policy.rb
@@ -1,4 +1,6 @@
 class CharacterPolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   class AlgoliaScope < AlgoliaScope
     def resolve
       ""

--- a/app/policies/character_voice_policy.rb
+++ b/app/policies/character_voice_policy.rb
@@ -1,1 +1,3 @@
-class CharacterVoicePolicy < ApplicationPolicy; end
+class CharacterVoicePolicy < ApplicationPolicy
+  administrated_by :database_mod
+end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -1,10 +1,11 @@
 class CommentPolicy < ApplicationPolicy
+  administrated_by :community_mod
   include GroupPermissionsHelpers
 
   def update?
     return false unless user
     return false if user.has_role?(:banned)
-    return true if is_admin?
+    return true if can_administrate?
     return true if group && has_group_permission?(:content)
     is_owner?
   end
@@ -23,7 +24,7 @@ class CommentPolicy < ApplicationPolicy
 
   def destroy?
     return true if group && has_group_permission?(:content)
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 
   def editable_attributes(all)

--- a/app/policies/community_recommendation_follow_policy.rb
+++ b/app/policies/community_recommendation_follow_policy.rb
@@ -8,6 +8,6 @@ class CommunityRecommendationFollowPolicy < ApplicationPolicy
   end
 
   def destroy?
-    is_owner? || can_administrate?
+    is_owner?
   end
 end

--- a/app/policies/community_recommendation_follow_policy.rb
+++ b/app/policies/community_recommendation_follow_policy.rb
@@ -8,6 +8,6 @@ class CommunityRecommendationFollowPolicy < ApplicationPolicy
   end
 
   def destroy?
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 end

--- a/app/policies/community_recommendation_policy.rb
+++ b/app/policies/community_recommendation_policy.rb
@@ -1,2 +1,3 @@
 class CommunityRecommendationPolicy < ApplicationPolicy
+  administrated_by :community_mod
 end

--- a/app/policies/community_recommendation_request_policy.rb
+++ b/app/policies/community_recommendation_request_policy.rb
@@ -1,6 +1,8 @@
 class CommunityRecommendationRequestPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def update?
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 
   def create?
@@ -8,6 +10,6 @@ class CommunityRecommendationRequestPolicy < ApplicationPolicy
   end
 
   def destroy?
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 end

--- a/app/policies/concerns/group_permissions_helpers.rb
+++ b/app/policies/concerns/group_permissions_helpers.rb
@@ -43,7 +43,7 @@ module GroupPermissionsHelpers
   # @return [Boolean] whether the current member has that permission
   def has_group_permission?(permission)
     return false unless group
-    return true if is_admin?
+    return true if has_permission?(:community_mod)
     member? && member.has_permission?(permission)
   end
 end

--- a/app/policies/drama_casting_policy.rb
+++ b/app/policies/drama_casting_policy.rb
@@ -1,2 +1,3 @@
 class DramaCastingPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/drama_character_policy.rb
+++ b/app/policies/drama_character_policy.rb
@@ -1,2 +1,3 @@
 class DramaCharacterPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/drama_policy.rb
+++ b/app/policies/drama_policy.rb
@@ -1,2 +1,3 @@
 class DramaPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/drama_staff_policy.rb
+++ b/app/policies/drama_staff_policy.rb
@@ -1,2 +1,3 @@
 class DramaStaffPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/dramas_media_attribute_policy.rb
+++ b/app/policies/dramas_media_attribute_policy.rb
@@ -1,4 +1,6 @@
 class DramasMediaAttributePolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   def create?
     false
   end

--- a/app/policies/episode_policy.rb
+++ b/app/policies/episode_policy.rb
@@ -1,2 +1,3 @@
 class EpisodePolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/franchise_policy.rb
+++ b/app/policies/franchise_policy.rb
@@ -1,2 +1,3 @@
 class FranchisePolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/genre_policy.rb
+++ b/app/policies/genre_policy.rb
@@ -1,2 +1,3 @@
 class GenrePolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/group_policy.rb
+++ b/app/policies/group_policy.rb
@@ -1,4 +1,5 @@
 class GroupPolicy < ApplicationPolicy
+  administrated_by :community_mod
   include GroupPermissionsHelpers
 
   def create?
@@ -14,12 +15,12 @@ class GroupPolicy < ApplicationPolicy
   end
 
   def editable_attributes(all)
-    return all if is_admin?
+    return all if can_administrate?
     all - %i[members_count leaders_count neighbors_count rules_formatted featured name]
   end
 
   def creatable_attributes(all)
-    return all if is_admin?
+    return all if can_administrate?
     all - %i[members_count leaders_count neighbors_count rules_formatted featured]
   end
 
@@ -29,7 +30,7 @@ class GroupPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope if user&.has_role?(:admin, Group)
+      return scope if can_administrate?
       return scope.visible_for(user) if see_nsfw?
       scope.sfw.visible_for(user)
     end

--- a/app/policies/installment_policy.rb
+++ b/app/policies/installment_policy.rb
@@ -1,2 +1,3 @@
 class InstallmentPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/list_import_policy.rb
+++ b/app/policies/list_import_policy.rb
@@ -1,6 +1,8 @@
 class ListImportPolicy < ApplicationPolicy
+  administrated_by :admin
+
   def create?
-    record.user == user || is_admin?
+    record.user == user || can_administrate?
   end
 
   def update?

--- a/app/policies/manga_character_policy.rb
+++ b/app/policies/manga_character_policy.rb
@@ -1,2 +1,3 @@
 class MangaCharacterPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/manga_media_attribute_policy.rb
+++ b/app/policies/manga_media_attribute_policy.rb
@@ -1,4 +1,6 @@
 class MangaMediaAttributePolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   def create?
     false
   end

--- a/app/policies/manga_policy.rb
+++ b/app/policies/manga_policy.rb
@@ -1,4 +1,6 @@
 class MangaPolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   class Scope < Scope
     def resolve
       if user && !user.sfw_filter?

--- a/app/policies/manga_staff_policy.rb
+++ b/app/policies/manga_staff_policy.rb
@@ -1,2 +1,3 @@
 class MangaStaffPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/mapping_policy.rb
+++ b/app/policies/mapping_policy.rb
@@ -1,2 +1,3 @@
 class MappingPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/media_attribute_policy.rb
+++ b/app/policies/media_attribute_policy.rb
@@ -1,4 +1,6 @@
 class MediaAttributePolicy < ApplicationPolicy
+  administrated_by :database_mod
+
   def create?
     false
   end

--- a/app/policies/media_character_policy.rb
+++ b/app/policies/media_character_policy.rb
@@ -1,1 +1,3 @@
-class MediaCharacterPolicy < ApplicationPolicy; end
+class MediaCharacterPolicy < ApplicationPolicy
+  administrated_by :database_mod
+end

--- a/app/policies/media_production_policy.rb
+++ b/app/policies/media_production_policy.rb
@@ -1,1 +1,3 @@
-class MediaProductionPolicy < ApplicationPolicy; end
+class MediaProductionPolicy < ApplicationPolicy
+  administrated_by :database_mod
+end

--- a/app/policies/media_reaction_policy.rb
+++ b/app/policies/media_reaction_policy.rb
@@ -1,4 +1,6 @@
 class MediaReactionPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def create?
     return false unless user
     return false if user.has_role?(:banned)
@@ -7,7 +9,7 @@ class MediaReactionPolicy < ApplicationPolicy
   alias_method :update?, :create?
 
   def destroy?
-    record.try(:user) == user || is_admin?
+    record.try(:user) == user || can_administrate?
   end
 
   class Scope < Scope

--- a/app/policies/media_relationship_policy.rb
+++ b/app/policies/media_relationship_policy.rb
@@ -1,2 +1,3 @@
 class MediaRelationshipPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/media_staff_policy.rb
+++ b/app/policies/media_staff_policy.rb
@@ -1,1 +1,3 @@
-class MediaStaffPolicy < ApplicationPolicy; end
+class MediaStaffPolicy < ApplicationPolicy
+  administrated_by :database_mod
+end

--- a/app/policies/person_policy.rb
+++ b/app/policies/person_policy.rb
@@ -1,2 +1,3 @@
 class PersonPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/post_policy.rb
+++ b/app/policies/post_policy.rb
@@ -1,10 +1,11 @@
 class PostPolicy < ApplicationPolicy
+  administrated_by :community_mod
   include GroupPermissionsHelpers
 
   def update?
     return false unless user
     return false if user.has_role?(:banned)
-    return true if is_admin?
+    return true if can_administrate?
     return true if group && has_group_permission?(:content)
     is_owner?
   end
@@ -24,7 +25,7 @@ class PostPolicy < ApplicationPolicy
 
   def destroy?
     return true if group && has_group_permission?(:content)
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 
   def editable_attributes(all)
@@ -37,7 +38,7 @@ class PostPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope if is_admin?
+      return scope if can_administrate?
       visible = scope.visible_for(user).where.not(user_id: blocked_users)
       return visible.sfw unless see_nsfw?
       visible

--- a/app/policies/pro_membership_plan_policy.rb
+++ b/app/policies/pro_membership_plan_policy.rb
@@ -1,7 +1,3 @@
 class ProMembershipPlanPolicy < ApplicationPolicy
-  def update?
-    is_admin?
-  end
-  alias_method :create?, :update?
-  alias_method :destroy?, :update?
+  administrated_by :admin
 end

--- a/app/policies/producer_policy.rb
+++ b/app/policies/producer_policy.rb
@@ -1,2 +1,3 @@
 class ProducerPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/quote_line_policy.rb
+++ b/app/policies/quote_line_policy.rb
@@ -1,1 +1,3 @@
-class QuoteLinePolicy < ApplicationPolicy; end
+class QuoteLinePolicy < ApplicationPolicy
+  administrated_by :database_mod
+end

--- a/app/policies/quote_policy.rb
+++ b/app/policies/quote_policy.rb
@@ -1,7 +1,3 @@
 class QuotePolicy < ApplicationPolicy
-  def update?
-    is_owner? && is_admin?
-  end
-  alias_method :create?, :update?
-  alias_method :destroy?, :update?
+  administrated_by :database_mod
 end

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -1,8 +1,10 @@
 class ReportPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   alias_method :create?, :is_owner?
 
   def update?
-    is_owner? || is_admin?(record.naughty)
+    is_owner? || can_administrate?
   end
 
   def destroy?
@@ -11,23 +13,11 @@ class ReportPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if is_global_admin?
+      if can_administrate?
         scope
-      elsif admin_scopes
-        scope.where(naughty_type: admin_scopes)
       else
         scope.where(user: user)
       end
-    end
-
-    def admin_scopes
-      if user
-        user.roles.where(name: 'admin', resource_id: nil).pluck(:resource_type)
-      end
-    end
-
-    def is_global_admin?
-      user&.has_role?(:admin) || user&.has_role?(:mod)
     end
   end
 end

--- a/app/policies/repost_policy.rb
+++ b/app/policies/repost_policy.rb
@@ -1,4 +1,6 @@
 class RepostPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def create?
     is_owner?
   end
@@ -8,6 +10,6 @@ class RepostPolicy < ApplicationPolicy
   end
 
   def destroy?
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 end

--- a/app/policies/review_policy.rb
+++ b/app/policies/review_policy.rb
@@ -1,10 +1,12 @@
 class ReviewPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def create?
     user.registered? && is_owner?
   end
 
   def update?
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 
   alias_method :destroy?, :update?

--- a/app/policies/site_announcement_policy.rb
+++ b/app/policies/site_announcement_policy.rb
@@ -1,7 +1,3 @@
 class SiteAnnouncementPolicy < ApplicationPolicy
-  def update?
-    is_admin?
-  end
-  alias_method :create?, :update?
-  alias_method :destroy?, :update?
+  administrated_by :admin
 end

--- a/app/policies/streamer_policy.rb
+++ b/app/policies/streamer_policy.rb
@@ -1,2 +1,3 @@
 class StreamerPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/streaming_link_policy.rb
+++ b/app/policies/streaming_link_policy.rb
@@ -1,2 +1,3 @@
 class StreamingLinkPolicy < ApplicationPolicy
+  administrated_by :database_mod
 end

--- a/app/policies/upload_policy.rb
+++ b/app/policies/upload_policy.rb
@@ -1,4 +1,6 @@
 class UploadPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def show?
     true
   end
@@ -12,7 +14,7 @@ class UploadPolicy < ApplicationPolicy
   end
 
   def destroy?
-    is_owner? || is_admin?
+    is_owner? || can_administrate?
   end
 
   class Scope < Scope

--- a/app/policies/user_ip_address_policy.rb
+++ b/app/policies/user_ip_address_policy.rb
@@ -1,4 +1,6 @@
 class UserIpAddressPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def update?
     false
   end
@@ -7,7 +9,7 @@ class UserIpAddressPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      is_admin? ? scope : scope.none
+      can_administrate? ? scope : scope.none
     end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,10 +1,12 @@
 class UserPolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def create?
     true
   end
 
   def update?
-    user == record || is_admin?
+    user == record || can_administrate?
   end
   alias_method :destroy?, :update?
 

--- a/app/policies/user_role_policy.rb
+++ b/app/policies/user_role_policy.rb
@@ -1,10 +1,12 @@
 class UserRolePolicy < ApplicationPolicy
+  administrated_by :community_mod
+
   def update?
     false
   end
 
   def create?
-    is_admin?
+    can_administrate?
   end
   alias_method :destroy?, :create?
 end

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -1,7 +1,8 @@
 class UserResource < BaseResource
   PRIVATE_FIELDS = %i[email password confirmed previous_email language time_zone country
                       share_to_global title_language_preference sfw_filter rating_system
-                      theme facebook_id has_password status subscribed_to_newsletter ao_pro].freeze
+                      theme facebook_id has_password status subscribed_to_newsletter ao_pro
+                      permissions].freeze
 
   attributes :name, :past_names, :slug, :about, :location, :waifu_or_husbando, :followers_count,
     :following_count, :life_spent_on_anime, :birthday, :gender, :comments_count, :favorites_count,

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -9,17 +9,17 @@ Flipper.configure do |config|
 end
 
 Flipper.register(:staff) do |user|
-  user.try(:has_role?, :admin)
+  user&.permissions&.admin?
 end
 
 Flipper.register(:pro) do |user|
-  user.try(:pro?)
+  user&.pro?
 end
 
 Flipper.register(:mod) do |user|
-  user.try(:has_role?, :mod) || user.try(:has_role?, :admin, Anime)
+  user&.permissions&.community_mod? || user&.permissions&.database_mod?
 end
 
 Flipper.register(:aozora) do |user|
-  user.try(:ao_id)
+  user&.ao_id
 end

--- a/spec/controllers/anime_controller_spec.rb
+++ b/spec/controllers/anime_controller_spec.rb
@@ -104,10 +104,10 @@ RSpec.describe AnimeController, type: :controller do
       }
     end
 
-    let(:admin) { create(:user, :admin) }
+    let(:database_mod) { create(:user, permissions: %i[database_mod]) }
 
     before do
-      sign_in admin
+      sign_in database_mod
     end
 
     it 'has status created' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -108,11 +108,7 @@ FactoryBot.define do
     password { Faker::Internet.password }
 
     trait :admin do
-      after(:create) { |user| user.add_role(:admin) }
-    end
-
-    trait :anime_admin do
-      after(:create) { |user| user.add_role(:admin, Anime) }
+      permissions { [:admin] }
     end
 
     trait :banned do

--- a/spec/policies/ama_policy_spec.rb
+++ b/spec/policies/ama_policy_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe AMAPolicy do
   let(:user) { token_for build(:user, id: 1) }
   let(:other) { token_for build(:user, id: 2) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:ama) { build(:ama, author: user.resource_owner) }
   subject { described_class }
 
   permissions :create? do
-    it('should allow admins') { should permit(admin, ama) }
+    it('should allow community mods') { should permit(community_mod, ama) }
     it('should not allow user') { should_not permit(user, ama) }
     it('should not allow other') { should_not permit(other, ama) }
   end

--- a/spec/policies/anime_policy_spec.rb
+++ b/spec/policies/anime_policy_spec.rb
@@ -3,14 +3,13 @@ require 'rails_helper'
 RSpec.describe AnimePolicy do
   let(:user) { token_for build(:user) }
   let(:pervert) { token_for build(:user, sfw_filter: false) }
-  let(:admin) { token_for create(:user, :admin) }
-  let(:mod) { token_for create(:user, :anime_admin) }
+  let(:database_mod) { token_for create(:user, permissions: %i[database_mod]) }
   let(:anime) { build(:anime) }
   let(:hentai) { build(:anime, :nsfw) }
   subject { described_class }
 
   permissions :create?, :update?, :destroy? do
-    it('should allow admins') { should permit(admin, anime) }
+    it('should allow database mods') { should permit(database_mod, anime) }
     it('should not allow normal users') { should_not permit(user, anime) }
     it('should not allow anon') { should_not permit(nil, anime) }
   end

--- a/spec/policies/comment_policy_spec.rb
+++ b/spec/policies/comment_policy_spec.rb
@@ -3,27 +3,27 @@ require 'rails_helper'
 RSpec.describe CommentPolicy do
   let(:owner) { token_for build(:user, id: 1) }
   let(:other) { token_for build(:user, id: 2) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:comment) { build(:comment, user: owner.resource_owner) }
   subject { described_class }
 
   permissions :update? do
     it('should allow owner') { should permit(owner, comment) }
-    it('should allow admin') { should permit(admin, comment) }
+    it('should allow community mod') { should permit(community_mod, comment) }
     it('should not allow other users') { should_not permit(other, comment) }
     it('should not allow anons') { should_not permit(nil, comment) }
   end
 
   permissions :create? do
     it('should allow owner') { should permit(owner, comment) }
-    it('should not allow admin') { should_not permit(admin, comment) }
+    it('should not allow community mod') { should_not permit(community_mod, comment) }
     it('should not allow random dude') { should_not permit(other, comment) }
     it('should not allow anon') { should_not permit(nil, comment) }
   end
 
   permissions :destroy? do
     it('should allow owner') { should permit(owner, comment) }
-    it('should allow admin') { should permit(admin, comment) }
+    it('should allow community mod') { should permit(community_mod, comment) }
     it('should now allow random dude') { should_not permit(other, comment) }
     it('should not allow anon') { should_not permit(nil, comment) }
   end

--- a/spec/policies/community_recommendation_follow_policy_spec.rb
+++ b/spec/policies/community_recommendation_follow_policy_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CommunityRecommendationFollowPolicy do
   let(:user) { token_for build(:user) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:follow) { build(:community_recommendation_follow, user: user.resource_owner) }
   let(:other) { build(:community_recommendation_follow) }
   subject { described_class }
@@ -16,14 +16,14 @@ RSpec.describe CommunityRecommendationFollowPolicy do
   permissions :create? do
     it('should allow for yourself') { should permit(user, follow) }
     it('should not allow anons') { should_not permit(nil, follow) }
-    it('should not for admin') { should_not permit(admin, follow) }
+    it('should not allow community mod') { should_not permit(community_mod, follow) }
     it('should not allow for others') { should_not permit(user, other) }
   end
 
   permissions :destroy? do
     it('should not allow anons') { should_not permit(nil, follow) }
     it('should allow for yourself') { should permit(user, follow) }
-    it('should allow for admin') { should permit(admin, follow) }
+    it('should allow for community mod') { should permit(community_mod, follow) }
     it('should not allow for others') { should_not permit(user, other) }
     it('should not allow for others') { should_not permit(user, other) }
   end

--- a/spec/policies/community_recommendation_follow_policy_spec.rb
+++ b/spec/policies/community_recommendation_follow_policy_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe CommunityRecommendationFollowPolicy do
   let(:user) { token_for build(:user) }
-  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:follow) { build(:community_recommendation_follow, user: user.resource_owner) }
   let(:other) { build(:community_recommendation_follow) }
   subject { described_class }
@@ -16,14 +15,12 @@ RSpec.describe CommunityRecommendationFollowPolicy do
   permissions :create? do
     it('should allow for yourself') { should permit(user, follow) }
     it('should not allow anons') { should_not permit(nil, follow) }
-    it('should not allow community mod') { should_not permit(community_mod, follow) }
     it('should not allow for others') { should_not permit(user, other) }
   end
 
   permissions :destroy? do
     it('should not allow anons') { should_not permit(nil, follow) }
     it('should allow for yourself') { should permit(user, follow) }
-    it('should allow for community mod') { should permit(community_mod, follow) }
     it('should not allow for others') { should_not permit(user, other) }
     it('should not allow for others') { should_not permit(user, other) }
   end

--- a/spec/policies/community_recommendation_request_policy_spec.rb
+++ b/spec/policies/community_recommendation_request_policy_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CommunityRecommendationRequestPolicy do
   let(:user) { token_for build(:user) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:request) { build(:community_recommendation_request, user: user.resource_owner) }
   let(:other) { build(:community_recommendation_request) }
   subject { described_class }
@@ -10,21 +10,21 @@ RSpec.describe CommunityRecommendationRequestPolicy do
   permissions :update? do
     it('should allow for yourself') { should permit(user, request) }
     it('should not allow anons') { should_not permit(nil, request) }
-    it('should allow for admin') { should permit(admin, request) }
+    it('should allow for community mod') { should permit(community_mod, request) }
     it('should not allow for others') { should_not permit(user, other) }
   end
 
   permissions :create? do
     it('should allow for yourself') { should permit(user, request) }
     it('should not allow anons') { should_not permit(nil, request) }
-    it('should not for admin') { should_not permit(admin, request) }
+    it('should not allow community mod') { should_not permit(community_mod, request) }
     it('should not allow for others') { should_not permit(user, other) }
   end
 
   permissions :destroy? do
     it('should not allow anons') { should_not permit(nil, request) }
     it('should allow for yourself') { should permit(user, request) }
-    it('should allow for admin') { should permit(admin, request) }
+    it('should allow for community mod') { should permit(community_mod, request) }
     it('should not allow for others') { should_not permit(user, other) }
   end
 end

--- a/spec/policies/library_entry_policy_spec.rb
+++ b/spec/policies/library_entry_policy_spec.rb
@@ -3,13 +3,11 @@ require 'rails_helper'
 RSpec.describe LibraryEntryPolicy do
   let(:owner) { token_for build(:user, id: 1) }
   let(:user) { token_for build(:user, id: 2) }
-  let(:admin) { token_for create(:user, :admin) }
   let(:entry) { build(:library_entry, user: owner.resource_owner) }
   subject { described_class }
 
   permissions :create?, :update?, :destroy? do
     it('should allow owner') { should permit(owner, entry) }
-    it('should not allow admin') { should_not permit(admin, entry) }
     it('should not allow random dude') { should_not permit(user, entry) }
     it('should not allow anon') { should_not permit(nil, entry) }
   end

--- a/spec/policies/linked_account_policy_spec.rb
+++ b/spec/policies/linked_account_policy_spec.rb
@@ -3,19 +3,14 @@ require 'rails_helper'
 RSpec.describe LinkedAccountPolicy do
   let(:owner) { token_for build(:user, id: 1) }
   let(:user) { token_for build(:user, id: 2) }
-  let(:admin) { token_for create(:user, :admin) }
   let(:linked_account) do
     build(:linked_account, user: owner.resource_owner)
   end
   subject { described_class }
 
-  # (it's much cleaner on one line)
-  # rubocop:disable Metrics/LineLength
   permissions :create?, :update?, :destroy? do
     it('should allow owner') { should permit(owner, linked_account) }
-    it('should not allow admin') { should_not permit(admin, linked_account) }
     it('should not allow random user') { should_not permit(user, linked_account) }
     it('should not allow anon') { should_not permit(nil, linked_account) }
   end
-  # rubocop:enable Metrics/LineLength
 end

--- a/spec/policies/media_reaction_policy_spec.rb
+++ b/spec/policies/media_reaction_policy_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe MediaReactionPolicy do
   let(:user) { token_for build(:user) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:anime) { build(:anime) }
   let(:media_reaction) do
     build(:media_reaction, user: user.resource_owner, anime: anime)
@@ -27,7 +27,7 @@ RSpec.describe MediaReactionPolicy do
   end
 
   permissions :destroy? do
-    it('should allow admin') { should permit(admin, media_reaction) }
+    it('should allow community mod') { should permit(community_mod, media_reaction) }
     it('should allow for yourself') {
       should permit(user, media_reaction)
     }

--- a/spec/policies/post_policy_spec.rb
+++ b/spec/policies/post_policy_spec.rb
@@ -3,27 +3,27 @@ require 'rails_helper'
 RSpec.describe PostPolicy do
   let(:owner) { token_for build(:user, id: 1) }
   let(:other) { token_for build(:user, id: 2) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:post) { build(:post, user: owner.resource_owner) }
   subject { described_class }
 
   permissions :update? do
     it('should allow owner') { should permit(owner, post) }
-    it('should allow admin') { should permit(admin, post) }
+    it('should allow community mod') { should permit(community_mod, post) }
     it('should not allow other users') { should_not permit(other, post) }
     it('should not allow anons') { should_not permit(nil, post) }
   end
 
   permissions :create? do
     it('should allow owner') { should permit(owner, post) }
-    it('should not allow admin') { should_not permit(admin, post) }
+    it('should not allow community mod') { should_not permit(community_mod, post) }
     it('should not allow random dude') { should_not permit(other, post) }
     it('should not allow anon') { should_not permit(nil, post) }
   end
 
   permissions :destroy? do
     it('should allow owner') { should permit(owner, post) }
-    it('should allow admin') { should permit(admin, post) }
+    it('should allow community mod') { should permit(community_mod, post) }
     it('should now allow random dude') { should_not permit(other, post) }
     it('should not allow anon') { should_not permit(nil, post) }
   end

--- a/spec/policies/quote_policy_spec.rb
+++ b/spec/policies/quote_policy_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe QuotePolicy do
   let(:other) { token_for build(:user) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:database_mod) { token_for create(:user, permissions: %i[database_mod]) }
   let(:quote) { build(:quote, user: admin.resource_owner) }
   subject { described_class }
 
   permissions :create?, :update?, :destroy? do
     it('should not allow anons') { should_not permit(nil, quote) }
     it('should not allow users') { should_not permit(other, quote) }
-    it('should allow admins') { should permit(admin, quote) }
+    it('should allow database mods') { should permit(database_mod, quote) }
   end
 end

--- a/spec/policies/quote_policy_spec.rb
+++ b/spec/policies/quote_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe QuotePolicy do
   let(:other) { token_for build(:user) }
   let(:database_mod) { token_for create(:user, permissions: %i[database_mod]) }
-  let(:quote) { build(:quote, user: admin.resource_owner) }
+  let(:quote) { build(:quote, user: database_mod.resource_owner) }
   subject { described_class }
 
   permissions :create?, :update?, :destroy? do

--- a/spec/policies/report_policy_spec.rb
+++ b/spec/policies/report_policy_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ReportPolicy do
   let(:user) { token_for build(:user, id: 1) }
   let(:other) { token_for build(:user, id: 2) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:report) { build(:report, user: user.resource_owner) }
   subject { described_class }
 
@@ -11,7 +11,7 @@ RSpec.describe ReportPolicy do
     it('should not allow anon') { should_not permit(nil, report) }
     it('should not allow random users') { should_not permit(other, report) }
     it('should allow the author') { should permit(user, report) }
-    it('should allow admins') { should permit(admin, report) }
+    it('should allow community mods') { should permit(community_mod, report) }
   end
 
   permissions :create? do
@@ -20,7 +20,7 @@ RSpec.describe ReportPolicy do
   end
 
   permissions :destroy? do
-    it('should not allow admin') { should_not permit(admin, report) }
+    it('should not allow community mods') { should_not permit(community_mod, report) }
     it('should not allow reporter') { should_not permit(user, report) }
   end
 end

--- a/spec/policies/upload_policy_spec.rb
+++ b/spec/policies/upload_policy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 RSpec.describe UploadPolicy do
   let(:user) { token_for build(:user) }
-  let(:admin) { token_for create(:user, :admin) }
+  let(:community_mod) { token_for create(:user, permissions: %i[community_mod]) }
   let(:upload) { build(:upload, user: user.resource_owner) }
   let(:other) { build(:upload) }
   subject { described_class }
@@ -26,6 +26,6 @@ RSpec.describe UploadPolicy do
     it('should not allow anons') { should_not permit(nil, upload) }
     it('should allow for yourself') { should permit(user, upload) }
     it('should not allow for others') { should_not permit(user, other) }
-    it('should allow admins') { should permit(admin, upload) }
+    it('should allow community mods') { should permit(community_mod, upload) }
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -3,14 +3,14 @@ require 'rails_helper'
 RSpec.describe UserPolicy do
   let(:user) { build(:user) }
   let(:user_token) { token_for(user) }
-  let(:admin) { create(:user, :admin) }
-  let(:admin_token) { token_for(admin) }
+  let(:community_mod) { create(:user, permissions: %i[community_mod]) }
+  let(:community_mod_token) { token_for(community_mod) }
   let(:other) { build(:user) }
   let(:other_token) { token_for(other) }
   subject { described_class }
 
   permissions :create? do
-    it('should allow admins') { should permit(admin_token, other) }
+    it('should allow community mods') { should permit(community_mod_token, other) }
     it('should allow normal users') { should permit(user_token, other) }
     it('should allow anon') { should permit(nil, other) }
   end
@@ -18,17 +18,17 @@ RSpec.describe UserPolicy do
   permissions :update? do
     context 'for self' do
       it('should allow normal users') { should permit(user_token, user) }
-      it('should allow admins') { should permit(admin_token, admin) }
+      it('should allow community mods') { should permit(community_mod_token, community_mod) }
     end
     context 'for other' do
       it('should not allow normal users') { should_not permit(user_token, other) }
       it('should not allow anons') { should_not permit(nil, other) }
-      it('should allow admins') { should permit(admin_token, other) }
+      it('should allow community mods') { should permit(community_mod_token, other) }
     end
   end
 
   permissions :destroy? do
-    it('should allow admins') { should permit(admin_token, other) }
+    it('should allow community mods') { should permit(community_mod_token, other) }
     it('should not allow normal users') { should_not permit(user_token, other) }
     it('should not allow anon') { should_not permit(nil, other) }
   end


### PR DESCRIPTION
# What

Switches permissions from rolify to active_flag, and integrates the new active_flag-based permissions into Pundit policies.

All policies state which role administers them (assuming it's a policy for something which is admin-managed)

# Why

Before, we used Rolify to set permissions by assigning users roles within scopes such as `:admin, Manga` and then Pundit would detect that and apply the permissions automatically based on the underlying model. This seemed magical as an idea, but never really aligned with how we think about permissions.

We have admins, community mods, and database mods. These... don't really map into Rolify well. Mostly when we added a new mod I would copy an existing mod's roles and pray that it worked. It often didn't, and this made all kinds of problems for the mod team.

This new approach creates a `permissions` bitfield with just three permissions for now: admin, community_mod, and database_mod. Each one is either true or false. Conveniently, active_flag fields are settable by factory_bot so we can just use `create(:user, permissions: %i[community_mod database_mod admin])` to get a user with all permissions enabled. It's really nice!
