### PR TITLE
(Extracted from #874) Add User permissions column

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ gem 'graphql-batch'
 gem 'jsonapi-resources', '0.9.0'
 
 # Miscellaneous Utilities
+gem 'active_flag' # Bitfields!
 gem 'addressable' # Fancy address logic
 gem 'counter_culture' # Fancier counter caches
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_flag (1.5.0)
+      activerecord (>= 5)
     activejob (5.1.7)
       activesupport (= 5.1.7)
       globalid (>= 0.3.6)
@@ -665,6 +667,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_flag
   activerecord-import
   addressable
   algoliasearch-rails

--- a/db/migrate/20200418043417_add_permissions_to_users.rb
+++ b/db/migrate/20200418043417_add_permissions_to_users.rb
@@ -1,0 +1,20 @@
+require 'update_in_batches'
+
+class AddPermissionsToUsers < ActiveRecord::Migration[5.1]
+  using UpdateInBatches
+
+  self.disable_ddl_transaction!
+
+  def up
+    add_column :users, :permissions, :integer, default: 0
+    say_with_time 'Filling permissions column' do
+      User.all.update_in_batches(permissions: 0)
+    end
+    change_column_null :users, :permissions, false, 0
+    change_column_default :users, :permissions, 0
+  end
+
+  def down
+    remove_column :users, :permissions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1605,6 +1605,7 @@ ActiveRecord::Schema.define(version: 20200822214657) do
     t.string "pro_message"
     t.string "pro_discord_user"
     t.integer "email_status", default: 0
+    t.integer "permissions", default: 0, null: false
     t.index "lower((email)::text)", name: "users_lower_idx"
     t.index ["ao_id"], name: "index_users_on_ao_id", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
This is just a chunk of #874 I wanna deploy first, which is adding the `permissions` column, so I can fill it before we switch reads over to it