### PR TITLE
ci(test): reduce number of action runs for non-fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,14 @@
 name: Kitsu Test Suite
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    # Branches from forks have the form 'user:branch-name' so we only run
+    # this job on pull_request events for branches that look like fork
+    # branches. Without this we would end up running this job twice for non
+    # forked PRs, once for the push and then once for opening the PR.
+    branches:
+    - '**:**'
 
 env:
   STREAM_API_KEY: q3k9n9kqk3fb


### PR DESCRIPTION
PRs from repo branches had 2 test actions run while forks only ran 1.

With this, PRs from repo branches only create 1 action.
