### PR TITLE
SlugLoader

### DIFF
--- a/app/graphql/loaders/slug_loader.rb
+++ b/app/graphql/loaders/slug_loader.rb
@@ -1,0 +1,9 @@
+class Loaders::SlugLoader < RecordLoader
+  def initialize(model, column: :slug, **args)
+    super(model, column: column, **args)
+  end
+
+  def cache_key(load_key)
+    load_key.downcase
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -41,7 +41,7 @@ class Types::QueryType < GraphQL::Schema::Object
   end
 
   def find_anime_by_slug(slug:)
-    RecordLoader.for(::Anime, column: :slug, token: context[:token]).load(slug)
+    Loaders::SlugLoader.for(::Anime, token: context[:token]).load(slug)
   end
 
   field :search_anime_by_title, Types::Anime.connection_type, null: false do
@@ -93,7 +93,7 @@ class Types::QueryType < GraphQL::Schema::Object
   end
 
   def find_manga_by_slug(slug:)
-    RecordLoader.for(::Manga, column: :slug, token: context[:token]).load(slug)
+    Loaders::SlugLoader.for(::Manga, token: context[:token]).load(slug)
   end
 
   field :search_manga_by_title, Types::Manga.connection_type, null: false do
@@ -204,7 +204,7 @@ class Types::QueryType < GraphQL::Schema::Object
   end
 
   def find_profile_by_slug(slug:)
-    RecordLoader.for(::User, column: :slug, token: context[:token]).load(slug)
+    Loaders::SlugLoader.for(::User, token: context[:token]).load(slug)
   end
 
   field :search_profile_by_username, Types::Profile.connection_type, null: true do
@@ -235,7 +235,7 @@ class Types::QueryType < GraphQL::Schema::Object
   end
 
   def find_character_by_slug(slug:)
-    RecordLoader.for(::Character, column: :slug, token: context[:token]).load(slug)
+    Loaders::SlugLoader.for(::Character, token: context[:token]).load(slug)
   end
 
   field :session, Types::Session,
@@ -277,7 +277,7 @@ class Types::QueryType < GraphQL::Schema::Object
   end
 
   def find_category_by_slug(slug:)
-    RecordLoader.for(::Category, column: :slug, token: context[:token]).load(slug)
+    Loaders::SlugLoader.for(::Category, token: context[:token]).load(slug)
   end
 
   field :lookup_mapping, Types::Union::MappingItem, null: true do
@@ -305,7 +305,7 @@ class Types::QueryType < GraphQL::Schema::Object
   end
 
   def find_person_by_slug(slug:)
-    RecordLoader.for(::Person, column: :slug, token: context[:token]).load(slug)
+    Loaders::SlugLoader.for(::Person, token: context[:token]).load(slug)
   end
 
   field :find_library_entry_by_id, Types::LibraryEntry, null: true do

--- a/db/migrate/20210126044815_convert_slugs_to_citext.rb
+++ b/db/migrate/20210126044815_convert_slugs_to_citext.rb
@@ -1,0 +1,113 @@
+class ConvertSlugsToCitext < ActiveRecord::Migration[5.1]
+  def change
+    Anime.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM anime
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |anime|
+      Anime.find(anime.id).update(slug: nil)
+    end
+    change_column :anime, :slug, 'citext USING slug::citext'
+
+    Manga.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM manga
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |manga|
+      Manga.find(manga.id).update(slug: nil)
+    end
+    change_column :manga, :slug, 'citext USING slug::citext'
+
+    Drama.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM dramas
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |drama|
+      Drama.find(drama.id).update(slug: nil)
+    end
+    change_column :dramas, :slug, 'citext USING slug::citext'
+
+    GroupCategory.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM group_categories
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |gc|
+      GroupCategory.find(gc.id).update(slug: nil)
+    end
+    change_column :group_categories, :slug, 'citext USING slug::citext'
+
+    Category.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM categories
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |category|
+      Category.find(category.id).update(slug: nil)
+    end
+    change_column :categories, :slug, 'citext USING slug::citext'
+
+    Genre.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM genres
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |genre|
+      Genre.find(genre.id).update(slug: nil)
+    end
+    change_column :genres, :slug, 'citext USING slug::citext'
+
+    Character.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM characters
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |character|
+      Character.find(character.id).update(slug: nil)
+    end
+    change_column :characters, :slug, 'citext USING slug::citext'
+
+    Person.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM people
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |person|
+      Person.find(person.id).update(slug: nil)
+    end
+    change_column :people, :slug, 'citext USING slug::citext'
+
+    Producer.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM producers
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |producer|
+      Producer.find(producer.id).update(slug: nil)
+    end
+    change_column :producers, :slug, 'citext USING slug::citext'
+
+    Group.find_by_sql("SELECT * FROM (
+      SELECT id,
+      ROW_NUMBER() OVER(PARTITION BY slug::citext ORDER BY id asc) AS row
+      FROM groups
+      WHERE slug IS NOT NULL
+    ) dups
+    WHERE dups.row > 1").each do |group|
+      Group.find(group.id).update(slug: nil)
+    end
+    change_column :groups, :slug, 'citext USING slug::citext'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201206202624) do
+ActiveRecord::Schema.define(version: 20210126044815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,7 +43,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
   end
 
   create_table "anime", id: :serial, force: :cascade do |t|
-    t.string "slug", limit: 255
+    t.citext "slug"
     t.integer "age_rating"
     t.integer "episode_count"
     t.integer "episode_length"
@@ -187,7 +187,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
 
   create_table "categories", id: :serial, force: :cascade do |t|
     t.string "title", null: false
-    t.string "slug", null: false
+    t.citext "slug", null: false
     t.integer "anidb_id"
     t.integer "parent_id"
     t.integer "total_media_count", default: 0, null: false
@@ -266,7 +266,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
     t.string "image_content_type", limit: 255
     t.integer "image_file_size"
     t.datetime "image_updated_at"
-    t.string "slug", limit: 255
+    t.citext "slug"
     t.integer "primary_media_id"
     t.string "primary_media_type"
     t.jsonb "names", default: {}, null: false
@@ -380,7 +380,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
   end
 
   create_table "dramas", id: :serial, force: :cascade do |t|
-    t.string "slug", null: false
+    t.citext "slug", null: false
     t.hstore "titles", default: {}, null: false
     t.string "canonical_title", default: "en_jp", null: false
     t.string "abbreviated_titles", default: [], null: false, array: true
@@ -520,7 +520,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
 
   create_table "genres", id: :serial, force: :cascade do |t|
     t.string "name", limit: 255
-    t.string "slug", limit: 255
+    t.citext "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "description", default: {}, null: false
@@ -565,7 +565,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
 
   create_table "group_categories", id: :serial, force: :cascade do |t|
     t.string "name", null: false
-    t.string "slug", null: false
+    t.citext "slug", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "description", default: {}, null: false
@@ -668,7 +668,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
 
   create_table "groups", id: :serial, force: :cascade do |t|
     t.string "name", limit: 255, null: false
-    t.string "slug", limit: 255, null: false
+    t.citext "slug", null: false
     t.text "about", default: "", null: false
     t.string "avatar_file_name", limit: 255
     t.string "avatar_content_type", limit: 255
@@ -837,7 +837,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
   end
 
   create_table "manga", id: :serial, force: :cascade do |t|
-    t.string "slug", limit: 255
+    t.citext "slug"
     t.string "poster_image_file_name", limit: 255
     t.string "poster_image_content_type", limit: 255
     t.integer "poster_image_file_size"
@@ -1168,7 +1168,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
     t.string "canonical_name", null: false
     t.string "other_names", default: [], null: false, array: true
     t.date "birthday"
-    t.string "slug"
+    t.citext "slug"
     t.jsonb "description", default: {}, null: false
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end
@@ -1259,7 +1259,7 @@ ActiveRecord::Schema.define(version: 20201206202624) do
 
   create_table "producers", id: :serial, force: :cascade do |t|
     t.string "name", limit: 255
-    t.string "slug", limit: 255
+    t.citext "slug"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/graphql/loaders/slug_loader_spec.rb
+++ b/spec/graphql/loaders/slug_loader_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Loaders::SlugLoader do
+  context 'with an uppercase slug' do
+    let!(:anime) { create(:anime, slug: 'ANIME-TEST') }
+
+    it 'should find with a lowercase slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('anime-test').then(&:slug)
+      end
+      expect(slug).to eq('ANIME-TEST')
+    end
+
+    it 'should find with an uppercase slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('ANIME-TEST').then(&:slug)
+      end
+      expect(slug).to eq('ANIME-TEST')
+    end
+
+    it 'should find with a mixed-case slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('ANIME-test').then(&:slug)
+      end
+      expect(slug).to eq('ANIME-TEST')
+    end
+  end
+
+  context 'with a lowercase slug' do
+    let!(:anime) { create(:anime, slug: 'anime-test') }
+
+    it 'should find with a lowercase slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('anime-test').then(&:slug)
+      end
+      expect(slug).to eq('anime-test')
+    end
+
+    it 'should find with an uppercase slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('ANIME-TEST').then(&:slug)
+      end
+      expect(slug).to eq('anime-test')
+    end
+
+    it 'should find with a mixed-case slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('ANIME-test').then(&:slug)
+      end
+      expect(slug).to eq('anime-test')
+    end
+  end
+
+  context 'with a mixed-case slug' do
+    let!(:anime) { create(:anime, slug: 'ANIME-test') }
+
+    it 'should find with a lowercase slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('anime-test').then(&:slug)
+      end
+      expect(slug).to eq('ANIME-test')
+    end
+
+    it 'should find with an uppercase slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('ANIME-TEST').then(&:slug)
+      end
+      expect(slug).to eq('ANIME-test')
+    end
+
+    it 'should find with a mixed-case slug' do
+      slug = GraphQL::Batch.batch do
+        Loaders::SlugLoader.for(Anime).load('ANIME-test').then(&:slug)
+      end
+      expect(slug).to eq('ANIME-test')
+    end
+  end
+end

--- a/spec/support/media_examples.rb
+++ b/spec/support/media_examples.rb
@@ -9,7 +9,7 @@ RSpec.shared_examples 'media' do
   end
 
   # Columns which are mandatory for all media
-  it { should have_db_column(:slug).of_type(:string) }
+  it { should have_db_column(:slug).of_type(:citext) }
   it { should have_db_column(:abbreviated_titles).of_type(:string) }
   it { should have_db_column(:average_rating).of_type(:decimal) }
   it { should have_db_column(:rating_frequencies).of_type(:hstore) }


### PR DESCRIPTION
# What
Solves the same problem that #893 attempted to

- Fixed duplicate slugs in all models
- Converted all `slug` fields to `citext` type
- Created a `SlugLoader` to handle loading things by their slug

# Why

## Fixing duplicate slugs
It turns out we have a number of slugs which were reused with different case, which breaks when we change to a citext column. To fix this, I have a query which uses window functions to find duplicates and then we set `slug: nil` to have friendly_id regenerate a slug for them.

## Converting all `slug` fields to `citext`
Slugs are case-insensitive, but we didn't always use `citext` to handle that. Traditionally, we used a normal string column and just downcased it, but that's not super reliable and Postgres has a lovely `citext` type which is perfect for this. We started using `citext` when we added slugs to users, but didn't ever switch other models to it, until now.

The reason why I did this as part of this PR is to completely solve the slug querying problem listed in comments on #893 

## Creating a `SlugLoader`
This is a very small loader class, inherited from `RecordLoader`, which just sets the query column to `slug` and converts the `cache_key` to lowercase. The reason for this is laid out in [a comment on #893](https://github.com/hummingbird-me/kitsu-server/pull/893#issuecomment-735041185), but basically boils down to the fact that loaders need to match loaded records to the call that asked for them, and they can't do that if the record's slug differs from the one that was passed in... unless we override `cache_key` to lowercase them both!

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
