### PR TITLE
GraphQL - update #total_count to use items instead of nodes

### DIFF
--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -3,7 +3,12 @@ class Types::BaseConnection < GraphQL::Types::Relay::BaseConnection
     null: false,
     description: 'The total amount of nodes.'
 
+  # NOTE: In 1.11.6 we used object.nodes,
+  # but in 1.12.0 they added the #first to limit the amount of nodes it gets.
+  # We now grab the object.items because that uses ActiveRecord direclty,
+  # instead of the #nodes method in graphql (which wraps AR).
+  # This will not trigger a limit based on the #first method and grab all records now.
   def total_count
-    object.nodes.count
+    object.items.count
   end
 end

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -3,11 +3,7 @@ class Types::BaseConnection < GraphQL::Types::Relay::BaseConnection
     null: false,
     description: 'The total amount of nodes.'
 
-  # NOTE: In 1.11.6 we used object.nodes,
-  # but in 1.12.0 they added the #first to limit the amount of nodes it gets.
-  # We now grab the object.items because that uses ActiveRecord direclty,
-  # instead of the #nodes method in graphql (which wraps AR).
-  # This will not trigger a limit based on the #first method and grab all records now.
+  # NOTE: In graphql 1.11.6 object.nodes was not limited by first. Now we use AR directly.
   def total_count
     object.items.count
   end


### PR DESCRIPTION
<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What

<!-- Please summarize your changes.  This includes:

- What bugs did you fix?
- What features did you add?
- Did you add any dependencies? -->

Fixes total_count not working on connections.

# Why

In graphql 1.11.6 we used object.nodes but in graphql 1.12.0 they added the `first` to limit the amount of nodes it gets. We now grab the `object.items` because that uses ActiveRecord directly instead of the `nodes` method in graphql (which wraps AR). This will not trigger a limit based on the `first` method and grab all records now.

<!-- Explain why you implemented this how you did.  This includes:

- What decisions did you make while building this?
- What are some alternatives you considered?
- What are some downsides of the approach you chose?
- Did you discuss those decisions with anyone else?  What were their thoughts? -->

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
