### PR TITLE
Move Site Announcements off Stream

### DIFF
--- a/app/actions/site_announcements/mark_read.rb
+++ b/app/actions/site_announcements/mark_read.rb
@@ -1,0 +1,15 @@
+module SiteAnnouncements
+  class MarkRead < Action
+    parameter :user, load: User, required: true
+    parameter :announcement_ids, required: true
+
+    def call
+      announcements = SiteAnnouncement.find(announcement_ids)
+
+      views = SiteAnnouncementView.ensure!(user, announcements)
+      views.each(&:read!)
+
+      { site_announcement_views: views }
+    end
+  end
+end

--- a/app/actions/site_announcements/mark_seen.rb
+++ b/app/actions/site_announcements/mark_seen.rb
@@ -1,0 +1,15 @@
+module SiteAnnouncements
+  class MarkSeen < Action
+    parameter :user, load: User, required: true
+    parameter :announcement_ids, required: true
+
+    def call
+      announcements = SiteAnnouncement.find(announcement_ids)
+
+      views = SiteAnnouncementView.ensure!(user, announcements)
+      views.each(&:seen!)
+
+      { site_announcement_views: views }
+    end
+  end
+end

--- a/app/graphql/mutations/site_announcements.rb
+++ b/app/graphql/mutations/site_announcements.rb
@@ -1,0 +1,9 @@
+class Mutations::SiteAnnouncements < Mutations::Namespace
+  field :mark_read,
+    mutation: Mutations::SiteAnnouncements::MarkRead,
+    description: 'Mark some announcements as read'
+
+  field :mark_seen,
+    mutation: Mutations::SiteAnnouncements::MarkSeen,
+    description: 'Mark some announcements as seen'
+end

--- a/app/graphql/mutations/site_announcements/mark_read.rb
+++ b/app/graphql/mutations/site_announcements/mark_read.rb
@@ -1,0 +1,16 @@
+class Mutations::SiteAnnouncements::MarkRead < Mutations::Base
+  argument :announcement_ids, [ID],
+    required: true,
+    description: 'Which site announcements to mark as read'
+  field :site_announcement_views, [Types::SiteAnnouncementView], null: true
+
+  def ready?
+    raise GraphQL::ExecutionError, ErrorI18n.t(NotLoggedInError) if user.blank?
+
+    true
+  end
+
+  def resolve(announcement_ids:)
+    SiteAnnouncements::MarkRead.call(user: user, announcement_ids: announcement_ids)
+  end
+end

--- a/app/graphql/mutations/site_announcements/mark_seen.rb
+++ b/app/graphql/mutations/site_announcements/mark_seen.rb
@@ -1,0 +1,16 @@
+class Mutations::SiteAnnouncements::MarkSeen < Mutations::Base
+  argument :announcement_ids, [ID],
+    required: true,
+    description: 'Which site announcements to mark as seen'
+  field :site_announcement_views, [Types::SiteAnnouncementView], null: true
+
+  def ready?
+    raise GraphQL::ExecutionError, ErrorI18n.t(NotLoggedInError) if user.blank?
+
+    true
+  end
+
+  def resolve(announcement_ids:)
+    SiteAnnouncements::MarkSeen.call(user: user, announcement_ids: announcement_ids)
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,6 +5,7 @@ class Types::MutationType < Types::BaseObject
   field :library_entry, Mutations::LibraryEntry, null: false
   field :mapping, Mutations::Mapping, null: false
   field :post, Mutations::Post, null: false
+  field :site_announcements, Mutations::SiteAnnouncements, null: false
 
   # HACK: The GraphQL runtime gets confused by the nil objects in mutations. So we override the
   # object method to just return a hash with all fields being hashes.

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,6 +1,19 @@
 class Types::QueryType < GraphQL::Schema::Object
   connection_type_class(Types::BaseConnection)
 
+  field :site_announcements, Types::SiteAnnouncementView.connection_type, null: false do
+    description 'All the site announcements'
+    argument :mark_seen, Boolean,
+      required: false,
+      description: 'Whether to mark the announcements as having been seen'
+  end
+
+  def site_announcements(mark_seen:)
+    announcements = ::SiteAnnouncementView.for_user(context[:user])
+    announcements.map(&:seen!) if mark_seen
+    announcements
+  end
+
   field :current_account, Types::Account, null: true do
     description 'Kitsu account details. You must supply an Authorization token in header.'
   end

--- a/app/graphql/types/site_announcement.rb
+++ b/app/graphql/types/site_announcement.rb
@@ -1,0 +1,36 @@
+class Types::SiteAnnouncement < Types::BaseObject
+  implements Types::Interface::WithTimestamps
+  include HasLocalizedField
+
+  description 'A site-wide announcement for all of Kitsu'
+
+  field :id, ID, null: false
+
+  field :title, String,
+    null: false,
+    description: 'A short title for the announcement'
+
+  localized_field :description,
+    null: true,
+    description: 'A brief sentence or two about this announcement'
+
+  field :link, String,
+    null: true,
+    description: 'A link to learn more about this announcement'
+
+  field :image_url, String,
+    null: true,
+    description: 'An image to go with this announcement'
+
+  field :author, Types::Profile,
+    null: false,
+    description: 'The user who made this announcement'
+
+  field :show_at, GraphQL::Types::ISO8601DateTime,
+    null: false,
+    description: 'The time to start showing this announcement'
+
+  field :hide_at, GraphQL::Types::ISO8601DateTime,
+    null: true,
+    description: 'The time to stop showing this announcement'
+end

--- a/app/graphql/types/site_announcement_view.rb
+++ b/app/graphql/types/site_announcement_view.rb
@@ -1,0 +1,17 @@
+class Types::SiteAnnouncementView < Types::BaseObject
+  description 'A wrapper marking whether you have seen or read a given SiteAnnouncement'
+
+  field :announcement, Types::SiteAnnouncement,
+    null: false,
+    description: 'The underlying site announcement'
+
+  field :read, Boolean,
+    null: false,
+    description: 'Whether the user has acknowledged/dismissed this site announcement',
+    method: :read?
+
+  field :seen, Boolean,
+    null: false,
+    description: 'Whether this site announcement has been displayed to the user',
+    method: :seen?
+end

--- a/app/models/site_announcement.rb
+++ b/app/models/site_announcement.rb
@@ -25,7 +25,8 @@ class SiteAnnouncement < ApplicationRecord
   belongs_to :user
   has_many :views, class_name: 'SiteAnnouncementView', dependent: :delete_all
 
-  scope :visible, -> { where('show_at < ? AND hide_at > ?', [Time.now, Time.now]) }
+  scope :visible, -> { where('show_at < NOW() AND (hide_at > NOW() OR hide_at IS NULL)') }
+  scope :newest_first, -> { order(show_at: :desc) }
 
   validates :title, presence: true
 

--- a/app/models/site_announcement.rb
+++ b/app/models/site_announcement.rb
@@ -22,7 +22,8 @@ class SiteAnnouncement < ApplicationRecord
   include WithActivity
   include DescriptionSanitation
 
-  belongs_to :user, required: true
+  belongs_to :user
+  has_many :views, class_name: 'SiteAnnouncementView', dependent: :delete_all
 
   validates :title, presence: true
 

--- a/app/models/site_announcement.rb
+++ b/app/models/site_announcement.rb
@@ -25,6 +25,8 @@ class SiteAnnouncement < ApplicationRecord
   belongs_to :user
   has_many :views, class_name: 'SiteAnnouncementView', dependent: :delete_all
 
+  scope :visible, -> { where('show_at < ? AND hide_at > ?', [Time.now, Time.now]) }
+
   validates :title, presence: true
 
   def stream_activity

--- a/app/models/site_announcement_view.rb
+++ b/app/models/site_announcement_view.rb
@@ -9,8 +9,54 @@ class SiteAnnouncementView < ApplicationRecord
     seen_at.present?
   end
 
+  # Mark this announcement as seen
+  def seen!
+    update(seen_at: Time.now)
+  end
+
   # Whether this SiteAnnouncement has been dismissed by the user
   def read?
     read_at.present?
+  end
+
+  # Mark this announcement as read
+  def read!
+    update(read_at: Time.now)
+  end
+
+  # Ensure rows exist for this user for all these announcements
+  #
+  # @param user [User] the user who we are viewing as
+  # @param announcements [SiteAnnouncement[]] the announcements we want to ensure we have views for
+  def self.ensure!(user, announcements)
+    existing = where(user: user, announcement: announcements).index_by(&:announcement_id)
+
+    to_create = announcements.map do |announcement|
+      existing.key?(announcement.id) ? nil : new(user: user, announcement: announcement)
+    end
+
+    import!(to_create.compact)
+
+    where(user: user, announcement: announcements)
+  end
+
+  # Get a list of anonymous SiteAnnouncementViews for when the user is logged out
+  def self.for_anonymous
+    SiteAnnouncement.visible.newest_first.map do |announcement|
+      new(user: nil, announcement: announcement)
+    end
+  end
+
+  # Get Relation for the user's views for all announcements they should see
+  #
+  # @param user [User] the user to get this for
+  def self.for_user(user)
+    if user.present?
+      ensure!(user, SiteAnnouncement.visible)
+        .joins(:announcement)
+        .merge(SiteAnnouncement.newest_first)
+    else
+      for_anonymous
+    end
   end
 end

--- a/app/models/site_announcement_view.rb
+++ b/app/models/site_announcement_view.rb
@@ -1,8 +1,8 @@
 class SiteAnnouncementView < ApplicationRecord
-  belongs_to :site_announcement
+  belongs_to :announcement, class_name: 'SiteAnnouncement'
   belongs_to :user
 
-  validate :user, uniqueness: { scope: :site_announcement_id }
+  validates :user, uniqueness: { scope: :announcement_id }
 
   # Whether this SiteAnnouncement has been displayed to the user at some point
   def seen?

--- a/app/models/site_announcement_view.rb
+++ b/app/models/site_announcement_view.rb
@@ -1,0 +1,16 @@
+class SiteAnnouncementView < ApplicationRecord
+  belongs_to :site_announcement
+  belongs_to :user
+
+  validate :user, uniqueness: { scope: :site_announcement_id }
+
+  # Whether this SiteAnnouncement has been displayed to the user at some point
+  def seen?
+    seen_at.present?
+  end
+
+  # Whether this SiteAnnouncement has been dismissed by the user
+  def read?
+    read_at.present?
+  end
+end

--- a/db/migrate/20210305230320_create_site_announcement_views.rb
+++ b/db/migrate/20210305230320_create_site_announcement_views.rb
@@ -1,11 +1,11 @@
 class CreateSiteAnnouncementViews < ActiveRecord::Migration[5.2]
   def change
     create_table :site_announcement_views do |t|
-      t.references :site_announcement, null: false
+      t.references :announcement, null: false
       t.references :user, null: false
       t.datetime :seen_at
       t.datetime :read_at
-      t.index %i[site_announcement_id user_id],
+      t.index %i[announcement_id user_id],
         unique: true,
         name: 'index_site_announcements_by_user_id'
     end

--- a/db/migrate/20210305230320_create_site_announcement_views.rb
+++ b/db/migrate/20210305230320_create_site_announcement_views.rb
@@ -1,0 +1,13 @@
+class CreateSiteAnnouncementViews < ActiveRecord::Migration[5.2]
+  def change
+    create_table :site_announcement_views do |t|
+      t.references :site_announcement, null: false
+      t.references :user, null: false
+      t.datetime :seen_at
+      t.datetime :read_at
+      t.index %i[site_announcement_id user_id],
+        unique: true,
+        name: 'index_site_announcements_by_user_id'
+    end
+  end
+end

--- a/db/migrate/20210305232334_add_start_and_end_to_site_announcements.rb
+++ b/db/migrate/20210305232334_add_start_and_end_to_site_announcements.rb
@@ -1,0 +1,8 @@
+class AddStartAndEndToSiteAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :site_announcements, :show_at, :datetime,
+      null: false,
+      default: -> { 'CURRENT_TIMESTAMP' }
+    add_column :site_announcements, :hide_at, :datetime
+  end
+end

--- a/db/migrate/20210316035000_seed_site_announcement_views.rb
+++ b/db/migrate/20210316035000_seed_site_announcement_views.rb
@@ -1,0 +1,18 @@
+class SeedSiteAnnouncementViews < ActiveRecord::Migration[5.2]
+  def up
+    execute 'SET statement_timeout TO DEFAULT'
+    execute <<-SQL
+      INSERT INTO site_announcement_views (user_id, announcement_id)
+      SELECT
+        users.id AS user_id,
+        site_announcements.id AS announcement_id
+      FROM users
+      CROSS JOIN site_announcements
+      ON CONFLICT DO NOTHING;
+    SQL
+  end
+
+  def down
+    execute 'TRUNCATE site_announcement_views'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210126044815) do
+ActiveRecord::Schema.define(version: 2021_03_05_230320) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "citext"
   enable_extension "hstore"
   enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
+  enable_extension "plpgsql"
 
   create_table "ama_subscribers", id: :serial, force: :cascade do |t|
     t.integer "ama_id", null: false
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 20210126044815) do
     t.jsonb "description", default: {}, null: false
     t.index ["age_rating"], name: "index_anime_on_age_rating"
     t.index ["average_rating"], name: "anime_average_rating_idx"
-    t.index ["average_rating"], name: "index_anime_on_wilson_ci", order: { average_rating: :desc }
+    t.index ["average_rating"], name: "index_anime_on_wilson_ci", order: :desc
     t.index ["slug"], name: "index_anime_on_slug", unique: true
     t.index ["user_count"], name: "index_anime_on_user_count"
   end
@@ -1408,6 +1408,16 @@ ActiveRecord::Schema.define(version: 20210126044815) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "original_ancestor_id"
+  end
+
+  create_table "site_announcement_views", force: :cascade do |t|
+    t.bigint "site_announcement_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "seen_at"
+    t.datetime "read_at"
+    t.index ["site_announcement_id", "user_id"], name: "index_site_announcements_by_user_id", unique: true
+    t.index ["site_announcement_id"], name: "index_site_announcement_views_on_site_announcement_id"
+    t.index ["user_id"], name: "index_site_announcement_views_on_user_id"
   end
 
   create_table "site_announcements", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_232334) do
+ActiveRecord::Schema.define(version: 2021_03_16_035000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_230320) do
+ActiveRecord::Schema.define(version: 2021_03_05_232334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1428,6 +1428,8 @@ ActiveRecord::Schema.define(version: 2021_03_05_230320) do
     t.string "title", null: false
     t.string "image_url"
     t.jsonb "description", default: {}, null: false
+    t.datetime "show_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "hide_at"
   end
 
   create_table "stats", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1411,12 +1411,12 @@ ActiveRecord::Schema.define(version: 2021_03_05_232334) do
   end
 
   create_table "site_announcement_views", force: :cascade do |t|
-    t.bigint "site_announcement_id", null: false
+    t.bigint "announcement_id", null: false
     t.bigint "user_id", null: false
     t.datetime "seen_at"
     t.datetime "read_at"
-    t.index ["site_announcement_id", "user_id"], name: "index_site_announcements_by_user_id", unique: true
-    t.index ["site_announcement_id"], name: "index_site_announcement_views_on_site_announcement_id"
+    t.index ["announcement_id", "user_id"], name: "index_site_announcements_by_user_id", unique: true
+    t.index ["announcement_id"], name: "index_site_announcement_views_on_announcement_id"
     t.index ["user_id"], name: "index_site_announcement_views_on_user_id"
   end
 

--- a/spec/actions/site_announcements/mark_read_spec.rb
+++ b/spec/actions/site_announcements/mark_read_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SiteAnnouncements::MarkRead do
+  it 'should return a set of announcements which have all been read' do
+    user = create(:user)
+    announcements = create_list(:site_announcement, 5)
+
+    result = described_class.call({
+      user: user,
+      announcement_ids: announcements.map(&:id)
+    })
+
+    expect(result.site_announcement_views).to all(be_read)
+  end
+end

--- a/spec/actions/site_announcements/mark_seen_spec.rb
+++ b/spec/actions/site_announcements/mark_seen_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SiteAnnouncements::MarkSeen do
+  it 'should return a set of announcements which have all been seen' do
+    user = create(:user)
+    announcements = create_list(:site_announcement, 5)
+
+    result = described_class.call({
+      user: user,
+      announcement_ids: announcements.map(&:id)
+    })
+
+    expect(result.site_announcement_views).to all(be_seen)
+  end
+end

--- a/spec/factories/site_announcement_views.rb
+++ b/spec/factories/site_announcement_views.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :site_announcement_view do
+    association :announcement, factory: :site_announcement
+    user
+  end
+end

--- a/spec/models/site_announcement_view_spec.rb
+++ b/spec/models/site_announcement_view_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe SiteAnnouncementView, type: :model do
+  describe '#seen?' do
+    it 'should return false if the seen_at is blank' do
+      model = build(:site_announcement_view, seen_at: nil)
+      expect(model.seen?).to eq(false)
+    end
+
+    it 'should return true if the seen_at is set' do
+      model = build(:site_announcement_view, seen_at: Time.now)
+      expect(model.seen?).to eq(true)
+    end
+  end
+
+  describe '#seen!' do
+    it 'should update the record to be seen' do
+      model = build(:site_announcement_view, seen_at: nil)
+      expect {
+        model.seen!
+      }.to change { model.seen? }.from(false).to(true)
+    end
+  end
+
+  describe '#read?' do
+    it 'should return false if the read_at is blank' do
+      model = build(:site_announcement_view, read_at: nil)
+      expect(model.read?).to eq(false)
+    end
+
+    it 'should return true if the read_at is set' do
+      model = build(:site_announcement_view, read_at: Time.now)
+      expect(model.read?).to eq(true)
+    end
+  end
+
+  describe '#read!' do
+    it 'should update the record to be read' do
+      model = build(:site_announcement_view, read_at: nil)
+      expect {
+        model.read!
+      }.to change { model.read? }.from(false).to(true)
+    end
+  end
+
+  describe '.for_user' do
+    context 'with user present' do
+      it 'should return a Relation of SiteAnnouncementViews for the user' do
+        user = create(:user)
+        create_list(:site_announcement, 5, show_at: 5.minutes.ago)
+
+        views = SiteAnnouncementView.for_user(user)
+        expect(views.count).to eq(5)
+        expect(views).to all(have_attributes(user: user))
+      end
+    end
+
+    context 'with no user' do
+      it 'should return an array of unsaved, anonymous SiteAnnouncementViews' do
+        create_list(:site_announcement, 5, show_at: 5.minutes.ago)
+
+        views = SiteAnnouncementView.for_user(nil)
+        expect(views.count).to eq(5)
+        expect(views).not_to include(be_persisted)
+        expect(views).to all(have_attributes(user: nil))
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What

- Create a SiteAnnouncementView table joining User with SiteAnnouncement and tracking read+seen status
  - The separate read+seen will allow us to show a different unread announcement each visit, by showing the least-recently-seen one!
- Expose the site announcement view through graphql

The next step will be rolling out a feature flag for client-side switching of the site announcement view to be backed by this

# Why

- Stream costs a lot of money, we should reserve it for actual feeds
- Marking announcements as seen is broken for some reason
- It's just all kinds of janky to use feeds for this

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
