### PR TITLE
Clean indices

### DIFF
--- a/db/migrate/20210427225015_remove_unused_indices.rb
+++ b/db/migrate/20210427225015_remove_unused_indices.rb
@@ -1,0 +1,21 @@
+class RemoveUnusedIndices < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  def change
+    # We no longer use substories
+    remove_index :substories, :created_at
+    remove_index :substories, :deleted_at
+    remove_index :substories, :story_id
+    remove_index :substories, :target_id
+    remove_index :substories, :user_id
+    # We already have LibraryEntries (user_id, media_type, media_id) so PG just uses prefix
+    remove_index :library_entries, %i[user_id media_type]
+    # These indexes are extremely space-inefficient and aren't used anyways
+    remove_index :library_events, :manga_id
+    remove_index :library_events, :anime_id
+    remove_index :library_events, :drama_id
+    # Replace them with partial indices
+    add_index :library_events, :manga_id, where: 'manga_id IS NOT NULL', algorithm: :concurrently
+    add_index :library_events, :anime_id, where: 'anime_id IS NOT NULL', algorithm: :concurrently
+    add_index :library_events, :drama_id, where: 'drama_id IS NOT NULL', algorithm: :concurrently
+  end
+end

--- a/db/migrate/20210427230857_create_partial_indices_on_library_entries.rb
+++ b/db/migrate/20210427230857_create_partial_indices_on_library_entries.rb
@@ -1,0 +1,13 @@
+class CreatePartialIndicesOnLibraryEntries < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+  def change
+    add_index :library_entries, :manga_id,
+      where: 'manga_id IS NOT NULL',
+      algorithm: :concurrently,
+      name: 'index_library_entries_on_manga_id_partial'
+    add_index :library_entries, :anime_id,
+      where: 'anime_id IS NOT NULL',
+      algorithm: :concurrently,
+      name: 'index_library_entries_on_anime_id_partial'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_05_030335) do
+ActiveRecord::Schema.define(version: 2021_04_27_225015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -763,7 +763,6 @@ ActiveRecord::Schema.define(version: 2021_04_05_030335) do
     t.index ["manga_id"], name: "index_library_entries_on_manga_id"
     t.index ["user_id", "anime_id"], name: "library_entries_user_id_anime_id_idx"
     t.index ["user_id", "media_type", "media_id"], name: "index_library_entries_on_user_id_and_media_type_and_media_id", unique: true
-    t.index ["user_id", "media_type"], name: "index_library_entries_on_user_id_and_media_type"
     t.index ["user_id", "status"], name: "index_library_entries_on_user_id_and_status"
     t.index ["user_id"], name: "index_library_entries_on_user_id"
   end
@@ -796,10 +795,10 @@ ActiveRecord::Schema.define(version: 2021_04_05_030335) do
     t.jsonb "changed_data", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["anime_id"], name: "index_library_events_on_anime_id"
-    t.index ["drama_id"], name: "index_library_events_on_drama_id"
+    t.index ["anime_id"], name: "index_library_events_on_anime_id", where: "(anime_id IS NOT NULL)"
+    t.index ["drama_id"], name: "index_library_events_on_drama_id", where: "(drama_id IS NOT NULL)"
     t.index ["library_entry_id"], name: "index_library_events_on_library_entry_id"
-    t.index ["manga_id"], name: "index_library_events_on_manga_id"
+    t.index ["manga_id"], name: "index_library_events_on_manga_id", where: "(manga_id IS NOT NULL)"
     t.index ["user_id"], name: "index_library_events_on_user_id"
   end
 
@@ -1488,11 +1487,6 @@ ActiveRecord::Schema.define(version: 2021_04_05_030335) do
     t.hstore "data"
     t.integer "substory_type", default: 0, null: false
     t.datetime "deleted_at"
-    t.index ["created_at"], name: "index_substories_on_created_at"
-    t.index ["deleted_at"], name: "index_substories_on_deleted_at"
-    t.index ["story_id"], name: "index_substories_on_story_id"
-    t.index ["target_id"], name: "index_substories_on_target_id"
-    t.index ["user_id"], name: "index_substories_on_user_id"
   end
 
   create_table "uploads", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_225015) do
+ActiveRecord::Schema.define(version: 2021_04_27_230857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -760,7 +760,9 @@ ActiveRecord::Schema.define(version: 2021_04_27_225015) do
     t.integer "media_reaction_id"
     t.integer "reaction_skipped", default: 0, null: false
     t.index ["anime_id"], name: "index_library_entries_on_anime_id"
+    t.index ["anime_id"], name: "index_library_entries_on_anime_id_partial", where: "(anime_id IS NOT NULL)"
     t.index ["manga_id"], name: "index_library_entries_on_manga_id"
+    t.index ["manga_id"], name: "index_library_entries_on_manga_id_partial", where: "(manga_id IS NOT NULL)"
     t.index ["user_id", "anime_id"], name: "library_entries_user_id_anime_id_idx"
     t.index ["user_id", "media_type", "media_id"], name: "index_library_entries_on_user_id_and_media_type_and_media_id", unique: true
     t.index ["user_id", "status"], name: "index_library_entries_on_user_id_and_status"


### PR DESCRIPTION
# What

A bunch of migrations cleaning up indices!

The substory indexes are worthless since we no longer use substories (they're only there for archival reasons) and take up almost 600MB each!

<img width="680" alt="image" src="https://user-images.githubusercontent.com/430411/116345469-06c1cb80-a79d-11eb-81e6-95ecba35c3ea.png">

The index on LibraryEntry (user_id, media_type) is covered by the other index on (user_id, media_type, media_id) so it's worthless, and it takes up 2GB to do absolutely fucking nothing.

<img width="680" alt="image" src="https://user-images.githubusercontent.com/430411/116345544-3375e300-a79d-11eb-8969-e8ad6097d881.png">

The indexes on LibraryEvent anime_id/drama_id/manga_id are unused, but may become used in future. But they also waste a lot of space on null values, so we could save a bunch of space by using partial indexes. I expect a roughly 50% reduction in index size for the anime_id and manga_id indexes, and a 100% reduction on the drama_id (since we never finished launching drama lists)

<img width="677" alt="image" src="https://user-images.githubusercontent.com/430411/116345782-aaab7700-a79d-11eb-9062-e0f2661e572a.png">

Following up on the partial index stuff, I added new partial indexes to LibraryEntries to reduce size on another big table. Since I'm scared to break anything on this core table, though, I've only added them and not removed any existing indexes. I'll follow up later with removal!

# Why
Unused indices have a cost during writes, and take up space on disk