### PR TITLE
Moving to Shrine: Step 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,10 +34,12 @@ gem 'blurhash', github: 'gargron/blurhash'
 gem 'delayed_paperclip'
 gem 'image_optim', require: false
 gem 'image_optim_pack', require: false
+gem 'image_processing'
 gem 'mini_magick'
 gem 'paperclip', '~> 6.0.0'
 gem 'paperclip-meta'
 gem 'paperclip-optimizer'
+gem 'shrine'
 
 # Background tasks
 gem 'sidekiq', '~> 5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
+    content_disposition (1.0.0)
     counter_culture (1.11.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -190,6 +191,8 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    down (5.2.1)
+      addressable (~> 2.5)
     e2mmap (0.1.0)
     elasticsearch (5.0.4)
       elasticsearch-api (= 5.0.4)
@@ -332,6 +335,9 @@ GEM
     image_optim_pack (0.7.0.20210206)
       fspath (>= 2.1, < 4)
       image_optim (~> 0.19)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     image_size (2.1.0)
     in_threads (1.5.4)
     jmespath (1.4.0)
@@ -609,6 +615,8 @@ GEM
     rspec-support (3.10.2)
     ruby-progressbar (1.11.0)
     ruby-statistics (2.1.3)
+    ruby-vips (2.1.0)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.2)
     rubyntlm (0.6.3)
     rufus-scheduler (3.6.0)
@@ -632,6 +640,9 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
+    shrine (3.3.0)
+      content_disposition (~> 1.0)
+      down (~> 5.1)
     sidekiq (5.2.9)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (~> 2.0)
@@ -759,6 +770,7 @@ DEPENDENCIES
   ice_cube
   image_optim
   image_optim_pack
+  image_processing
   json_expressions
   jsonapi-resources (= 0.9.0)
   jwt
@@ -809,6 +821,7 @@ DEPENDENCIES
   sass-rails
   sentry-raven
   shoulda-matchers
+  shrine
   sidekiq (~> 5)
   sidekiq-debounce
   sidekiq-scheduler

--- a/app/models/list_import.rb
+++ b/app/models/list_import.rb
@@ -31,6 +31,7 @@ class ListImport < ApplicationRecord
   enum strategy: %i[greater obliterate]
   enum status: %i[queued running failed completed partially_failed]
   has_attached_file :input_file
+  include PaperclipShrineSynchronization
   alias_attribute :kind, :type
 
   validates :strategy, presence: true

--- a/app/uploaders/list_import_uploader.rb
+++ b/app/uploaders/list_import_uploader.rb
@@ -1,0 +1,3 @@
+class ListImportUploader < Shrine
+
+end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -1,0 +1,12 @@
+require 'shrine/storage/s3'
+require 'paperclip_shrine_synchronization'
+
+s3_options = {
+  bucket: 'kitsu-media',
+  region: 'us-east-1'
+}
+
+Shrine.storages = {
+  cache: Shrine::Storage::S3.new(prefix: 'cache', **s3_options),
+  store: Shrine::Storage::S3.new(**s3_options),
+}

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -8,5 +8,5 @@ s3_options = {
 
 Shrine.storages = {
   cache: Shrine::Storage::S3.new(prefix: 'cache', **s3_options),
-  store: Shrine::Storage::S3.new(**s3_options),
+  store: Shrine::Storage::S3.new(**s3_options)
 }

--- a/db/migrate/20210506021756_add_input_file_data_to_list_imports.rb
+++ b/db/migrate/20210506021756_add_input_file_data_to_list_imports.rb
@@ -1,0 +1,5 @@
+class AddInputFileDataToListImports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :list_imports, :input_file_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_230857) do
+ActiveRecord::Schema.define(version: 2021_05_06_021756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -836,6 +836,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_230857) do
     t.text "error_trace"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "input_file_data"
   end
 
   create_table "manga", id: :serial, force: :cascade do |t|

--- a/vendor/paperclip_shrine_synchronization.rb
+++ b/vendor/paperclip_shrine_synchronization.rb
@@ -1,0 +1,80 @@
+# Borrowed from https://shrinerb.com/docs/paperclip#2-dual-write
+# Covered by the MIT license at https://github.com/shrinerb/shrine/blob/master/LICENSE.txt
+# Slightly modified to support paperclip-meta and our own blurhash integration
+
+module PaperclipShrineSynchronization
+  def self.included(model)
+    model.before_save do
+      Paperclip::AttachmentRegistry.each_definition do |klass, name, options|
+        write_shrine_data(name) if changes.key?(:"#{name}_file_name") && klass == self.class
+      end
+    end
+  end
+
+  def write_shrine_data(name)
+    attachment = send(name)
+    attacher   = Shrine::Attacher.from_model(self, name)
+
+    if attachment.size.present?
+      attacher.set shrine_file(attachment)
+
+      attachment.styles.each do |style_name, style|
+        attacher.merge_derivatives(style_name => shrine_file(style))
+      end
+    else
+      attacher.set nil
+    end
+  end
+
+  private
+
+  def shrine_file(object)
+    if object.is_a?(Paperclip::Attachment)
+      shrine_attachment_file(object)
+    else
+      shrine_style_file(object)
+    end
+  end
+
+  def shrine_attachment_file(attachment)
+    location = attachment.path
+    # if you're storing files on disk, make sure to subtract the absolute path
+    location = location.sub(%r{^#{storage.prefix}/}, "") if storage.prefix
+
+    Shrine.uploaded_file(
+      storage:  :store,
+      id:       location,
+      metadata: {
+        "height"    => attachment.height,
+        "width"     => attachment.width,
+        "blurhash"  => attachment.blurhash,
+        "size"      => attachment.size,
+        "filename"  => attachment.original_filename,
+        "mime_type" => attachment.content_type,
+      }
+    )
+  end
+
+  # If you'll be using a `:prefix` on your Shrine storage, or you're storing
+  # files on the filesystem, make sure to subtract the appropriate part
+  # from the path assigned to `:id`.
+  def shrine_style_file(style)
+    location = style.attachment.path(style.name)
+    # if you're storing files on disk, make sure to subtract the absolute path
+    location = location.sub(%r{^#{storage.prefix}/}, "") if storage.prefix
+
+    Shrine.uploaded_file(
+      storage:  :store,
+      id:       location,
+      metadata: {
+        "height" => attachment.height(style.name),
+        "width"  => attachment.width(style.name),
+        "size": attachment.size(style.name)
+      },
+    )
+  end
+
+  def storage
+    Shrine.storages[:store]
+  end
+end

--- a/vendor/paperclip_shrine_synchronization.rb
+++ b/vendor/paperclip_shrine_synchronization.rb
@@ -5,7 +5,7 @@
 module PaperclipShrineSynchronization
   def self.included(model)
     model.before_save do
-      Paperclip::AttachmentRegistry.each_definition do |klass, name, options|
+      Paperclip::AttachmentRegistry.each_definition do |klass, name, _options|
         write_shrine_data(name) if changes.key?(:"#{name}_file_name") && klass == self.class
       end
     end
@@ -39,18 +39,18 @@ module PaperclipShrineSynchronization
   def shrine_attachment_file(attachment)
     location = attachment.path
     # if you're storing files on disk, make sure to subtract the absolute path
-    location = location.sub(%r{^#{storage.prefix}/}, "") if storage.prefix
+    location = location.sub(%r{^#{storage.prefix}/}, '') if storage.prefix
 
     Shrine.uploaded_file(
-      storage:  :store,
-      id:       location,
+      storage: :store,
+      id: location,
       metadata: {
-        "height"    => attachment.height,
-        "width"     => attachment.width,
-        "blurhash"  => attachment.blurhash,
-        "size"      => attachment.size,
-        "filename"  => attachment.original_filename,
-        "mime_type" => attachment.content_type,
+        'height' => attachment.height,
+        'width' => attachment.width,
+        'blurhash' => attachment.blurhash,
+        'size' => attachment.size,
+        'filename' => attachment.original_filename,
+        'mime_type' => attachment.content_type
       }
     )
   end
@@ -61,16 +61,16 @@ module PaperclipShrineSynchronization
   def shrine_style_file(style)
     location = style.attachment.path(style.name)
     # if you're storing files on disk, make sure to subtract the absolute path
-    location = location.sub(%r{^#{storage.prefix}/}, "") if storage.prefix
+    location = location.sub(%r{^#{storage.prefix}/}, '') if storage.prefix
 
     Shrine.uploaded_file(
-      storage:  :store,
-      id:       location,
+      storage: :store,
+      id: location,
       metadata: {
-        "height" => attachment.height(style.name),
-        "width"  => attachment.width(style.name),
+        'height' => attachment.height(style.name),
+        'width' => attachment.width(style.name),
         "size": attachment.size(style.name)
-      },
+      }
     )
   end
 


### PR DESCRIPTION
# What

Start the process of moving from Paperclip to Shrine.

Specifically this begins the dual-write phase for ListImports. Once this is merged, I can migrate all the existing data and switch code to use the Shrine fields. Then we can remove Paperclip on this model and repeat for all the other models 😬 

# Why

Paperclip is unmaintained, and the top spot is now ActiveStorage. Sadly, ActiveStorage kinda sucks for public files, and isn't flexible enough for our needs. Shrine is the new #2, and it's way more flexible and can handle public files reliably.

