### PR TITLE
Update Rubocop and Hound

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,3 @@
 rubocop:
   config_file: .rubocop.yml
-  version: 0.83.0
+  version: 1.5.2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
-require: rubocop-rails
+require:
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-performance
 AllCops:
+  NewCops: enable
   Exclude:
     - db/**/*
     - bin/**/*
@@ -7,7 +11,7 @@ AllCops:
   DisplayCopNames: false
   DisplayStyleGuide: true
   StyleGuideCopsOnly: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
 Style/BlockDelimiters:

--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,12 @@ group :development, :test do
   gem 'pry-rails' # Better Console
   gem 'spring' # Faster CLI
 
+  # Rubocop stuff
+  gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
+
   # Development+Testing
   gem 'database_cleaner' # Clean the database fully before doing anything
   gem 'factory_bot_rails' # Factories > Fixtures

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       actionpack (>= 4.2)
       graphql (>= 1.8)
     arel (9.0.0)
+    ast (2.4.2)
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
     aws-eventstream (1.1.1)
@@ -462,6 +463,8 @@ GEM
     parallel (1.20.1)
     paranoia (2.4.3)
       activerecord (>= 4.0, < 6.2)
+    parser (3.0.1.1)
+      ast (~> 2.4.1)
     pg (1.2.3)
     pg_query (2.0.3)
       google-protobuf (~> 3.15.5)
@@ -545,6 +548,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (13.0.3)
     ranked-model (0.4.7)
       activerecord (>= 4.2)
@@ -572,6 +576,7 @@ GEM
       redis-store (>= 1.2, < 2)
     redis-store (1.9.0)
       redis (>= 4, < 5)
+    regexp_parser (2.1.1)
     remotipart (1.4.4)
     representable (3.0.4)
       declarative (< 0.1.0)
@@ -613,6 +618,27 @@ GEM
       rspec-core (~> 3.0, >= 3.0.0)
       sidekiq (>= 2.4.0)
     rspec-support (3.10.2)
+    rubocop (1.5.2)
+      parallel (~> 1.10)
+      parser (>= 2.7.1.5)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (1.5.0)
+      parser (>= 3.0.1.1)
+    rubocop-performance (1.10.2)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.9.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.90.0, < 2.0)
+    rubocop-rspec (2.3.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     ruby-statistics (2.1.3)
     ruby-vips (2.1.0)
@@ -713,6 +739,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    unicode-display_width (1.7.0)
     webmock (3.12.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -816,6 +843,10 @@ DEPENDENCIES
   rolify
   rspec-rails
   rspec-sidekiq
+  rubocop
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   ruby-progressbar
   sanitize
   sass-rails


### PR DESCRIPTION
Also adds a few Rubocop extensions for things we use, and enables all new cops by default (we'll shut them up as we find bad ones)