### PR TITLE
Wordfiltering

### DIFF
--- a/app/callbacks/wordfilter_callbacks.rb
+++ b/app/callbacks/wordfilter_callbacks.rb
@@ -1,0 +1,37 @@
+class WordfilterCallbacks < InstancedCallbacks
+  # @param klass [Class] the class to hook the callbacks for
+  # @param location [Symbol] the wordfilter location name
+  # @param content_field [Symbol] the field on this class which stores the content
+  def self.hook(klass, location, content_field)
+    super(klass, { location: location, content_field: content_field })
+
+    attach_callback(klass, :before_validation)
+    attach_callback(klass, :after_save)
+  end
+
+  def before_validation
+    record.send(:"#{options.content_field}=", wordfilter.censored_text) if wordfilter.censor?
+    record.hidden_at = Time.now if wordfilter.hide?
+    record.errors.add options.content_field, 'contains an inappropriate word' if wordfilter.reject?
+  end
+
+  def after_save
+    return unless wordfilter.report?
+
+    Report.create!(
+      user: User.system_user,
+      naughty: record,
+      reason: :other,
+      explanation: 'Caught by wordfilter'
+    )
+  end
+
+  private
+
+  def wordfilter
+    @wordfilter ||= WordfilterService.new(
+      options.location,
+      record.public_send(options.content_field)
+    )
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -35,6 +35,7 @@ class Comment < ApplicationRecord
   include WithActivity
   include ContentProcessable
   include ContentEmbeddable
+  WordfilterCallbacks.hook(self, :comment, :content)
 
   acts_as_paranoid
   resourcify

--- a/app/models/media_reaction.rb
+++ b/app/models/media_reaction.rb
@@ -40,6 +40,7 @@
 
 class MediaReaction < ApplicationRecord
   include WithActivity
+  WordfilterCallbacks.hook(self, :reaction, :reaction)
 
   acts_as_paranoid
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -44,6 +44,7 @@ class Post < ApplicationRecord
   include WithActivity
   include ContentProcessable
   include ContentEmbeddable
+  WordfilterCallbacks.hook(self, :post, :content)
 
   acts_as_paranoid
   resourcify

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -70,7 +70,10 @@ class Post < ApplicationRecord
   scope :sfw, -> { where(nsfw: false) }
   scope :in_group, ->(group) { where(target_group: group) }
   scope :visible_for, ->(user) {
-    where(target_group_id: Group.visible_for(user)).or(where(target_group_id: nil))
+    where(target_group_id: Group.visible_for(user))
+      .or(where(target_group_id: nil))
+      .where(hidden_at: nil)
+      .or(where(user_id: user).where.not(hidden_at: nil))
   }
 
   validates :content, :content_formatted, presence: true, unless: :uploads

--- a/app/models/wordfilter.rb
+++ b/app/models/wordfilter.rb
@@ -1,9 +1,10 @@
 class Wordfilter < ApplicationRecord
   flag :locations, %i[post comment reaction]
   enum action: {
-    report: 10,
-    hide: 20,
-    reject: 30
+    censor: 10,
+    report: 20,
+    hide: 30,
+    reject: 40
   }, _prefix: 'action_'
 
   validates :pattern, presence: true

--- a/app/models/wordfilter.rb
+++ b/app/models/wordfilter.rb
@@ -1,0 +1,21 @@
+class Wordfilter < ApplicationRecord
+  flag :locations, %i[post comment reaction]
+  enum action: {
+    report: 10,
+    hide: 20,
+    reject: 30
+  }, _prefix: 'action_'
+
+  validates :pattern, presence: true
+
+  scope :matching, ->(text) {
+    # Match regexes with ~* and create an exact match via ILIKE
+    where("? ~* ('.*' || pattern || '.*')", text).where(regex_enabled: true).or(
+      where("? ILIKE ('%' || pattern || '%')", text).where(regex_enabled: false)
+    )
+  }
+
+  def self.action_for(location, text)
+    matching(text).where_locations(location).order(action: :desc).first&.action&.to_sym
+  end
+end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -45,7 +45,9 @@ class CommentPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where.not(user_id: blocked_users)
+      scope
+        .where.not(user_id: blocked_users)
+        .where(hidden_at: nil).or(scope.where(user_id: user).where.not(hidden_at: nil))
     end
   end
 end

--- a/app/policies/media_reaction_policy.rb
+++ b/app/policies/media_reaction_policy.rb
@@ -14,7 +14,9 @@ class MediaReactionPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.where.not(user_id: blocked_users)
+      scope
+        .where.not(user_id: blocked_users)
+        .where(hidden_at: nil).or(scope.where(user_id: user).where.not(hidden_at: nil))
     end
   end
 end

--- a/app/services/wordfilter_service.rb
+++ b/app/services/wordfilter_service.rb
@@ -1,0 +1,40 @@
+class WordfilterService
+  def initialize(location, text)
+    @location = location
+    @text = text
+  end
+
+  def reject?
+    wordfilters[:reject].present?
+  end
+
+  def hide?
+    wordfilters[:hide].present?
+  end
+
+  def report?
+    wordfilters[:report].present?
+  end
+
+  def censor?
+    wordfilters[:censor].present?
+  end
+
+  def censored_text
+    wordfilters[:censor].inject(@text) do |text, wordfilter|
+      # Convert SQL LIKE roughly into Regex
+      pattern = if wordfilter.regex_enabled? then wordfilter.pattern
+                else wordfilter.pattern.gsub('.', '\.').gsub('%', '.*').tr('_', '.')
+                end
+      pattern = Regexp.new(pattern, Regexp::IGNORECASE)
+
+      text.gsub(pattern, 'CENSORED')
+    end
+  end
+
+  private
+
+  def wordfilters
+    Wordfilter.where_locations(@location).matching(@text).group_by(&:action).symbolize_keys
+  end
+end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -248,6 +248,37 @@ RailsAdmin.config do |config|
   config.model('Comment') { parent Post }
   config.model('Repost') { parent Post }
   config.model('Upload') { parent Post }
+  config.model('Wordfilter') do
+    weight(-5)
+    navigation_label 'Social'
+    object_label_method { :pattern }
+    field :pattern, :string do
+      help <<~HELP.squish.html_safe
+        <b>Required.</b> The pattern to trigger this action on.<br /><br />
+        <b>If regex is enabled:</b> this is a case-insensitive PCRE (Perl-compatible Regular
+        Expression), not wrapped in slashes.<br /><br />
+        <b>If regex is <i>not</i> enabled:</b> this is an SQL LIKE expression. In this mode,
+        percent sign (%), underscore (_), backslash (\\) have special meaning. Percent sign (%)
+        means "any number of any characters" and underscore (_) means "any one character". If you
+        want to match an actual percent sign, underscore, or backslash, preface them with a
+        backslash (\\) to "escape" them, or ask for help!
+      HELP
+    end
+
+    field :regex_enabled, :boolean
+    field :locations, :flags
+
+    field :action, :enum do
+      help <<~HELP.html_safe
+        Specifies which action to take when this wordfilter matches:<ul>
+        <li><b>Censor</b> - replaces the naughty phrase with "CENSORED"</li>
+        <li><b>Report</b> - automatically creates a Report</li>
+        <li><b>Hide</b> - hides the content from other users, but allows the poster to see it</li>
+        <li><b>Reject</b> - displays an error to the user when they try to submit</li></ul>
+      HELP
+    end
+  end
+
   config.model('Review') { navigation_label 'Social' }
   config.model('MediaReaction') { navigation_label 'Social' }
   config.model('MediaReactionVote') { parent MediaReaction }

--- a/db/migrate/20210605015255_create_wordfilters.rb
+++ b/db/migrate/20210605015255_create_wordfilters.rb
@@ -1,0 +1,11 @@
+class CreateWordfilters < ActiveRecord::Migration[5.2]
+  def change
+    create_table :wordfilters do |t|
+      t.text :pattern, null: false
+      t.boolean :regex_enabled, null: false, default: false
+      t.integer :locations, null: false, default: 0
+      t.integer :action, null: false, default: 0
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20210613042826_add_hidden_at_to_user_content.rb
+++ b/db/migrate/20210613042826_add_hidden_at_to_user_content.rb
@@ -1,0 +1,7 @@
+class AddHiddenAtToUserContent < ActiveRecord::Migration[5.2]
+  def change
+    add_column :media_reactions, :hidden_at, :datetime
+    add_column :posts, :hidden_at, :datetime
+    add_column :comments, :hidden_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1709,6 +1709,15 @@ ActiveRecord::Schema.define(version: 2021_06_05_031927) do
     t.index ["user_id"], name: "index_wiki_submissions_on_user_id"
   end
 
+  create_table "wordfilters", force: :cascade do |t|
+    t.text "pattern", null: false
+    t.boolean "regex_enabled", default: false, null: false
+    t.integer "locations", default: 0, null: false
+    t.integer "action", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "ama_subscribers", "amas"
   add_foreign_key "amas", "posts", column: "original_post_id"
   add_foreign_key "anime_castings", "anime_characters"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_05_031927) do
+ActiveRecord::Schema.define(version: 2021_06_13_042826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -303,6 +303,7 @@ ActiveRecord::Schema.define(version: 2021_06_05_031927) do
     t.datetime "edited_at"
     t.jsonb "embed"
     t.string "ao_id"
+    t.datetime "hidden_at"
     t.index ["ao_id"], name: "index_comments_on_ao_id", unique: true
     t.index ["deleted_at"], name: "index_comments_on_deleted_at"
     t.index ["parent_id"], name: "index_comments_on_parent_id"
@@ -1010,6 +1011,7 @@ ActiveRecord::Schema.define(version: 2021_06_05_031927) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"
+    t.datetime "hidden_at"
     t.index ["anime_id"], name: "index_media_reactions_on_anime_id"
     t.index ["deleted_at"], name: "index_media_reactions_on_deleted_at"
     t.index ["drama_id"], name: "index_media_reactions_on_drama_id"
@@ -1222,6 +1224,7 @@ ActiveRecord::Schema.define(version: 2021_06_05_031927) do
     t.integer "locked_by_id"
     t.datetime "locked_at"
     t.integer "locked_reason"
+    t.datetime "hidden_at"
     t.index ["ao_id"], name: "index_posts_on_ao_id", unique: true
     t.index ["community_recommendation_id"], name: "index_posts_on_community_recommendation_id"
     t.index ["deleted_at"], name: "index_posts_on_deleted_at"

--- a/spec/callbacks/wordfilter_callbacks_spec.rb
+++ b/spec/callbacks/wordfilter_callbacks_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe WordfilterCallbacks do
+  describe '.hook' do
+    it 'attaches a before_validation hook' do
+      klass = class_spy(Post)
+      described_class.hook(klass, :location, :content_field)
+      expect(klass).to have_received(:before_validation)
+    end
+
+    it 'attaches an after_save hook' do
+      klass = class_spy(Post)
+      described_class.hook(klass, :location, :content_field)
+      expect(klass).to have_received(:after_save)
+    end
+  end
+
+  describe '#before_validation' do
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Model
+        attr_accessor :hidden_at, :content
+      end
+    end
+
+    context 'with a hide wordfilter' do
+      let(:wordfilter) do
+        OpenStruct.new(censor?: false, report?: false, hide?: true, reject?: false)
+      end
+
+      it 'censors the text in the content field' do
+        record = klass.new(content: 'uncensored', hidden_at: nil)
+        callbacks = described_class.new(record, content_field: :content)
+        allow(callbacks).to receive(:wordfilter).and_return(wordfilter)
+        callbacks.before_validation
+        expect(record.hidden_at).not_to be_nil
+      end
+    end
+
+    context 'with a censor wordfilter' do
+      let(:wordfilter) do
+        OpenStruct.new(
+          censor?: true,
+          censored_text: 'censored',
+          report?: false,
+          hide?: false,
+          reject?: false
+        )
+      end
+
+      it 'censors the text in the content field' do
+        record = klass.new(content: 'uncensored', hidden_at: nil)
+        callbacks = described_class.new(record, content_field: :content)
+        allow(callbacks).to receive(:wordfilter).and_return(wordfilter)
+        callbacks.before_validation
+        expect(record.content).to eq('censored')
+      end
+    end
+
+    context 'with a reject wordfilter' do
+      let(:wordfilter) do
+        OpenStruct.new(censor?: false, report?: false, hide?: false, reject?: true)
+      end
+
+      it 'censors the text in the content field' do
+        record = klass.new(content: 'uncensored', hidden_at: nil)
+        callbacks = described_class.new(record, content_field: :content)
+        allow(callbacks).to receive(:wordfilter).and_return(wordfilter)
+        callbacks.before_validation
+        expect(record.errors[:content]).to include('contains an inappropriate word')
+      end
+    end
+  end
+
+  describe '#after_save' do
+    context 'with a report wordfilter' do
+      let(:wordfilter) do
+        OpenStruct.new(censor?: false, report?: true, hide?: false, reject?: false)
+      end
+
+      it 'censors the text in the content field' do
+        report_klass = class_spy(Report)
+        stub_const('Report', report_klass)
+        callbacks = described_class.new({}, content_field: :content)
+        allow(User).to receive(:system_user).and_return(-10)
+        allow(callbacks).to receive(:wordfilter).and_return(wordfilter)
+
+        callbacks.after_save
+        expect(report_klass).to have_received(:create!)
+      end
+    end
+  end
+end

--- a/spec/factories/wordfilters.rb
+++ b/spec/factories/wordfilters.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :wordfilter do
+    pattern { 'pattern' }
+  end
+end

--- a/spec/models/wordfilter_spec.rb
+++ b/spec/models/wordfilter_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe Wordfilter do
+  it { is_expected.to validate_presence_of(:pattern) }
+
+  describe '.matching(text)' do
+    context 'when regex_enabled = true' do
+      it 'matches like a regular expression' do
+        filter = create(:wordfilter, pattern: 'fee+t', regex_enabled: true)
+
+        expect(described_class.matching('feeeeeeeeeeeet').first).to eq(filter)
+      end
+
+      it 'matches case insensitively' do
+        filter = create(:wordfilter, pattern: 'fee+t', regex_enabled: true)
+
+        expect(described_class.matching('FEEEEEET').first).to eq(filter)
+      end
+
+      it 'matches anywhere in the text' do
+        filter = create(:wordfilter, pattern: 'fee+t', regex_enabled: true)
+
+        expect(described_class.matching('she got dem feeeet').first).to eq(filter)
+      end
+
+      it 'does not return exact matches' do
+        create(:wordfilter, pattern: 'fee+t', regex_enabled: true)
+
+        expect(described_class.matching('fee+t')).to be_empty
+      end
+    end
+
+    context 'when regex_enabled = false' do
+      it 'matches with LIKE patterns' do
+        filter = create(:wordfilter, pattern: 'f__t', regex_enabled: false)
+
+        expect(described_class.matching('foot').first).to eq(filter)
+      end
+
+      it 'matches case insensitively' do
+        filter = create(:wordfilter, pattern: 'feet', regex_enabled: false)
+
+        expect(described_class.matching('FEET').first).to eq(filter)
+      end
+
+      it 'matches anywhere in the text' do
+        filter = create(:wordfilter, pattern: 'feet', regex_enabled: false)
+
+        expect(described_class.matching('she got dem feet yo').first).to eq(filter)
+      end
+    end
+  end
+
+  describe '.action_for(location, text)' do
+    it 'returns the most-severe action which applies' do
+      create(:wordfilter, pattern: 'feet', action: :report, locations: %i[post])
+      create(:wordfilter, pattern: 'slur', action: :reject, locations: %i[post])
+
+      expect(described_class.action_for(:post, 'feet is a slur')).to eq(:reject)
+    end
+
+    it 'only finds wordfilters for a given location' do
+      create(:wordfilter, pattern: 'feet', action: :report, locations: %i[post])
+      create(:wordfilter, pattern: 'suck', action: :reject, locations: %i[reaction])
+
+      expect(described_class.action_for(:post, 'feet suck, fools')).to eq(:report)
+    end
+  end
+end

--- a/spec/services/wordfilter_service_spec.rb
+++ b/spec/services/wordfilter_service_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe WordfilterService do
+  context 'with only a reject wordfilter' do
+    before do
+      create(:wordfilter, action: :reject, pattern: 'test', locations: %i[post])
+    end
+
+    let(:service) { described_class.new(:post, 'this is a test post') }
+
+    describe '#reject?' do
+      it('returns true') { expect(service).to be_reject }
+    end
+
+    describe '#hide?' do
+      it('returns false') { expect(service).not_to be_hide }
+    end
+  end
+
+  context 'with reject and hide wordfilters' do
+    before do
+      create(:wordfilter, action: :reject, pattern: 'test', locations: %i[post])
+      create(:wordfilter, action: :hide, pattern: 'post', locations: %i[post])
+    end
+
+    let(:service) { described_class.new(:post, 'this is a test post') }
+
+    describe '#reject?' do
+      it('returns true') { expect(service).to be_reject }
+    end
+
+    describe '#hide?' do
+      it('returns true') { expect(service).to be_hide }
+    end
+  end
+
+  context 'with basic censor wordfilter' do
+    before do
+      create(:wordfilter, action: :censor, pattern: 'options', locations: %i[post])
+    end
+
+    let(:service) { described_class.new(:post, 'we should add some options') }
+
+    describe '#censor?' do
+      it('returns true') { expect(service).to be_censor }
+    end
+
+    describe '#censored_text' do
+      it 'returns the content with censorship applied' do
+        expect(service.censored_text).to eq('we should add some CENSORED')
+      end
+    end
+  end
+
+  context 'with LIKE censor wordfilter' do
+    before do
+      create(:wordfilter, action: :censor, pattern: 'j_sh', locations: %i[post])
+    end
+
+    let(:service) { described_class.new(:post, 'praise josh') }
+
+    describe '#censor?' do
+      it('returns true') { expect(service).to be_censor }
+    end
+
+    describe '#censored_text' do
+      it 'returns the content with censorship applied' do
+        expect(service.censored_text).to eq('praise CENSORED')
+      end
+    end
+  end
+
+  context 'with multiple regex censor wordfilters' do
+    before do
+      create(:wordfilter,
+        action: :censor,
+        pattern: 'we*abo*',
+        locations: %i[post],
+        regex_enabled: true)
+      create(:wordfilter,
+        action: :censor,
+        pattern: 'b(i|eeyo)tch',
+        locations: %i[post],
+        regex_enabled: true)
+    end
+
+    let(:service) { described_class.new(:post, 'you are a WEEABOO bitch') }
+
+    describe '#censor?' do
+      it('returns true') { expect(service).to be_censor }
+    end
+
+    describe '#censored_text' do
+      it 'returns the content with censorship applied' do
+        expect(service.censored_text).to eq('you are a CENSORED CENSORED')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What

- Adds an `InstancedCallbacks` superclass for encapsulating lifecycle callbacks, which handles options way better than the old `Callbacks` superclass and allows internal state across multiple callbacks (gasp!)
- Adds a System user to do stuff as automated systems
- Adds a `hidden_at` field to Posts, Comments, and Reactions which allows shadowbanning them
- Adds a new Rails Admin field type for `flags`, encapsulating an ActiveFlag field
- Adds a wordfilter system

# Why

We want a wordfilter system to help with moderation. So we need two things:
1. A way to hook up to content submission and apply wordfiltering
2. A way for mods to to add/remove/edit wordfilters

For (1) we want to encapsulate a reusable set of callbacks, but we also want to maintain state across before_validation and after_save so that we're not requerying the database. To that end, I built the `InstancedCallbacks` superclass.

For (2) we want to have the ability to specify which scopes the action should apply in, so I built a new `flags` field type.

I also wanted to allow shadowbanning content, since it's helpful for conflict-avoidance, so I added `hidden_at`.

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
