### PR TITLE
Add flags field type to rails admin

### DIFF
--- a/app/views/rails_admin/main/_form_flags.html.haml
+++ b/app/views/rails_admin/main/_form_flags.html.haml
@@ -1,0 +1,5 @@
+= form.collection_check_boxes(field.method_name, field.pairs, :last, :first) do |box|
+  %div{ class: "checkbox" }
+    = box.label do
+      = box.check_box
+      = box.text

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -2,6 +2,7 @@ require Rails.root.join('lib/rails_admin/config/fields/types/citext')
 require Rails.root.join('lib/rails_admin/config/fields/types/localized_string')
 require Rails.root.join('lib/rails_admin/config/fields/types/localized_text')
 require Rails.root.join('lib/rails_admin/config/fields/types/string_list')
+require Rails.root.join('lib/rails_admin/config/fields/types/flags')
 
 RailsAdmin::ApplicationHelper.module_exec do
   def edit_user_link
@@ -14,7 +15,7 @@ RailsAdmin::ApplicationHelper.module_exec do
   end
 end
 
-RailsAdmin.config do |config| # rubocop:disable Metrics/BlockLength
+RailsAdmin.config do |config|
   config.parent_controller = '::AdminController'
   config.current_user_method(&:current_user)
 

--- a/lib/rails_admin/config/fields/types/flags.rb
+++ b/lib/rails_admin/config/fields/types/flags.rb
@@ -1,0 +1,36 @@
+module RailsAdmin
+  module Config
+    module Fields
+      module Types
+        class Flags < RailsAdmin::Config::Fields::Base
+          RailsAdmin::Config::Fields::Types.register(self)
+
+          def value
+            bindings[:object].public_send(name)
+          end
+
+          def generic_help
+            ''
+          end
+
+          register_instance_option :partial do
+            :form_flags
+          end
+
+          register_instance_option :pairs do
+            bindings[:object].class.send(name).pairs.transform_keys(&:titleize)
+          end
+
+          register_instance_option :pretty_value do
+            bindings[:view].safe_join(value.flat_map do |flag|
+              [
+                bindings[:view].tag.span(flag.to_s.titleize, class: 'label label-primary'),
+                ' '
+              ]
+            end)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a flags field type to rails admin to allow editing ActiveFlag bitfields

The code is kinda shite but that's normal for Rails Admin stuff