### PR TITLE
Add InstancedCallbacks base class

### DIFF
--- a/app/callbacks/instanced_callbacks.rb
+++ b/app/callbacks/instanced_callbacks.rb
@@ -1,0 +1,47 @@
+# Encapsulates a set of life-cycle callbacks on a class
+class InstancedCallbacks
+  attr_reader :record
+
+  # @param record [ActiveRecord::Base] the record on which the callbacks are being run
+  # @param options [Hash] a hash of options to this
+  def initialize(record, options = {})
+    @record = record
+    @_options = options
+  end
+
+  # The options provided to this, wrapped in an OpenStruct
+  def options
+    @options ||= OpenStruct.new(@_options)
+  end
+
+  # Attach the callbacks to an ActiveSupport::Callbacks-enabled class
+  # @param klass [ActiveSupport::Callbacks] the object to hook onto
+  # @param options [Hash] a hash of options to this
+  def self.hook(klass, options = {})
+    this = self
+
+    klass.define_method(name) do
+      if instance_variable_defined?(:"@#{this.name}")
+        instance_variable_get(:"@#{this.name}")
+      else
+        instance_variable_set(:"@#{this.name}", this.new(self, options))
+      end
+    end
+  end
+
+  # Attach a named callback to the class, calling the local method with the same name
+  def self.attach_callback(klass, name)
+    klass.send(name, wrap_callback(name))
+  end
+
+  # Returns a Proc which retrieves the instance from self and calls the given method on it
+  # @param method [Symbol] the method to call
+  def self.wrap_callback(method)
+    instance_getter = :"#{name}"
+
+    proc do
+      send(instance_getter).send(method)
+    end
+  end
+  private_class_method :wrap_callback
+end

--- a/spec/callbacks/instanced_callbacks_spec.rb
+++ b/spec/callbacks/instanced_callbacks_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe InstancedCallbacks do
+  describe '#record' do
+    it 'returns the record passed in during initialization' do
+      foo = double
+      expect(described_class.new(foo).record).to eq(foo)
+    end
+  end
+
+  describe '#options' do
+    it 'wraps the initialization options as an OpenStruct' do
+      opts = { foo: 'bar' }
+      expect(described_class.new(nil, opts).options.foo).to eq('bar')
+    end
+  end
+
+  describe '.hook' do
+    describe 'defines a new method on the provided class' do
+      it 'returns an instance of the callback class' do
+        klass = Class.new
+        described_class.hook(klass)
+        instance = klass.new
+        expect(instance.InstancedCallbacks).to be_a(described_class)
+      end
+
+      it 'returns the same instance when called multiple times' do
+        klass = Class.new
+        described_class.hook(klass)
+        instance = klass.new
+        expect(instance.InstancedCallbacks).to be(instance.InstancedCallbacks)
+      end
+
+      it 'uses the name of the callback subclass' do
+        stub_const('TestCallbacks', Class.new(described_class))
+        klass = Class.new
+        TestCallbacks.hook(klass)
+        instance = klass.new
+        expect(instance.TestCallbacks).to be_a(TestCallbacks)
+      end
+    end
+  end
+
+  describe '.attach_callback' do
+    it 'attaches a callback with the given name' do
+      klass = class_spy(ActiveRecord::Base)
+      described_class.attach_callback(klass, :before_save)
+      expect(klass).to have_received(:before_save)
+    end
+  end
+
+  describe '.wrap_callback' do
+    it 'wraps a method call to be bound to the instance' do
+      callbacks = spy(described_class)
+      fake_object = spy(ActiveRecord::Base)
+      allow(fake_object).to receive(:InstancedCallbacks).and_return(callbacks)
+      proc = described_class.send(:wrap_callback, :before_save)
+      fake_object.instance_exec(&proc)
+      expect(callbacks).to have_received(:before_save)
+    end
+  end
+end


### PR DESCRIPTION
Provides a base class for reusable callbacks with:

1. shared internal state
2. better support for options