### PR TITLE
Make post/comment content nullable

### DIFF
--- a/app/graphql/types/comment.rb
+++ b/app/graphql/types/comment.rb
@@ -15,11 +15,11 @@ class Types::Comment < Types::BaseObject
     method: :user
 
   field :content, String,
-    null: false,
+    null: true,
     description: 'Unmodified content.'
 
   field :content_formatted, String,
-    null: false,
+    null: true,
     description: 'Html formatted content.'
 
   field :parent, Types::Comment,

--- a/app/graphql/types/post.rb
+++ b/app/graphql/types/post.rb
@@ -25,11 +25,11 @@ class Types::Post < Types::BaseObject
     method: :nsfw?
 
   field :content, String,
-    null: false,
+    null: true,
     description: 'Unmodified content.'
 
   field :content_formatted, String,
-    null: false,
+    null: true,
     description: 'Html formatted content.'
 
   field :locked_by, Types::Profile,


### PR DESCRIPTION
# What

Made the content in posts and comments nullable because they can be null in the database.

<img src="https://user-images.githubusercontent.com/16106839/126048247-6b6868f6-d2ba-47db-afb0-69ad71fdd079.png" width="200px"> <img src="https://user-images.githubusercontent.com/16106839/126048259-4d54d880-eccc-48e4-a61f-07528cb34789.png" width="500px">

Second image shows the error I got previously


# Why

It fixes an error when using the GraphQL API where if the post has no content, only an upload, the server will throw an error.

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [ ] Tests have been added to cover the new code
