### PR TITLE
Create NullClient for prometheus in dev/test

### DIFF
--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -6,9 +6,9 @@ Rails.application.middleware.unshift PrometheusExporter::Middleware
 if Rails.env.development? || Rails.env.test?
   require 'prometheus_exporter/server'
 
-  server = PrometheusExporter::Server::WebServer.new bind: 'localhost', port: 9394
-  server.start
-  PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(
-    collector: server.collector
-  )
+  class NullClient < PrometheusExporter::Client
+    def send(*); end
+  end
+
+  PrometheusExporter::Client.default = NullClient.new
 end


### PR DESCRIPTION
# What

- Creates a new NullClient for prometheus which just does nothing
- Uses the NullClient in dev/test instead of spinning up a collector and binding 9394

# Why

We don't actually need Prometheus in dev/test, but anything which ships metrics will explode if there's not a Prometheus collector client configured, so we had a thing to spin up an in-process collector. That worked great, as long as you only had one process at a time, otherwise it would try to bind 9394 and explode.

But we don't actually give a shit about the data, we're not reading it anyways! Enter the NullClient: it's a PrometheusExporter::Client which just throws away any data it receives, no server required. Problem solved.
