### PR TITLE
Fancy Mutations, Mutators, and Account Creation

### DIFF
--- a/app/graphql/concerns/fancy_mutation.rb
+++ b/app/graphql/concerns/fancy_mutation.rb
@@ -43,7 +43,12 @@ module FancyMutation
 
     raise ActiveRecord::Rollback unless warnings.blank? || ignore_warnings
 
-    { result: result, warnings: warnings, errors: errors }
+    {
+      # If the mutation returns the errors list, ignore it (it's not the actual result)
+      result: (result unless result == errors),
+      warnings: warnings,
+      errors: errors
+    }
   end
 
   def errors

--- a/app/graphql/concerns/fancy_mutation.rb
+++ b/app/graphql/concerns/fancy_mutation.rb
@@ -41,7 +41,7 @@ module FancyMutation
   def resolve_with_support(ignore_warnings: false, **args)
     result = super(**args)
 
-    raise ActiveRecord::Rollback unless warnings.blank? || ignore_warnings
+    raise ActiveRecord::Rollback if warnings.present? && !ignore_warnings
 
     {
       # If the mutation returns the errors list, ignore it (it's not the actual result)

--- a/app/graphql/concerns/fancy_mutation.rb
+++ b/app/graphql/concerns/fancy_mutation.rb
@@ -1,11 +1,44 @@
+# Provides a bunch of helpers for our standard mutation structure, making consistency easy!
+#
+# @example
+#   class Mutations::Post::Like < Mutations::Base
+#     # Pass a description here to be used in the GraphQL schema
+#     description 'Like a post'
+#     # Build your input type here (set arguments)
+#     input do
+#       argument :postId, ID,
+#         required: true,
+#         description: 'The post to like'
+#     end
+#     # Your result type should generally expose what changed so clients can update their cache
+#     result Types::Post
+#     # Build the union of errors which you may return
+#     errors Types::Errors::NotAuthorized,
+#       Types::Errors::NotAuthenticated,
+#       Types::Errors::Conflict
+#
+#     def resolve(post_id:)
+#       return errors << Types::Errors::NotAuthenticated.build unless context[:current_user]
+#       # In most cases you'll want to delegate to a Mutator class so the logic can be unit-tested.
+#       PostMutator.like(post: Post.find(post_id), user: context[:current_user])
+#     rescue ActiveRecord::RecordInvalid => e
+#       errors << Types::Errors::Conflict.build
+#     rescue Pundit::NotAuthorizedError => e
+#       errors << Types::Errors::NotAuthorized.build
+#     end
+#   end
 module FancyMutation
   extend ActiveSupport::Concern
 
   class_methods do
+    # Sets the result type
+    # @param type [Class] The GraphQL type to use for the result
     def result(type, **kwargs)
       field :result, type, **kwargs
     end
 
+    # Sets up an input type and field for the mutation
+    # @param block [Proc] A block defining the input type fields
     def input(&block)
       input_name = "#{graphql_name}Input"
       input = Class.new(Types::Input::Base) do
@@ -15,6 +48,8 @@ module FancyMutation
       argument :input, input, required: true
     end
 
+    # Sets up the union of error types for the mutation
+    # @param types [Array<Class>] The error types this can return
     def errors(*types)
       union_name = "#{graphql_name}ErrorsUnion"
       union = Class.new(Types::Union::Base) do
@@ -28,6 +63,8 @@ module FancyMutation
       field :errors, [union], null: true
     end
 
+    # Sets up the union of warning types for the mutation
+    # @param types [Array<Class>] The warning types this can return
     def warnings(*types)
       union_name = "#{graphql_name}WarningsUnion"
       union = Class.new(Types::Union::Base) do
@@ -38,6 +75,12 @@ module FancyMutation
     end
   end
 
+  # Wraps the resolve method with some support. When ignore_warnings is false or not set, it will
+  # rollback when there are warnings. In all cases, the return value of the resolve method will be
+  # wrapped as the :result field, so that the mutation always returns the correct structure. When
+  # the return value is the errors list, we ignore it, so that we won't accidentally try to treat it
+  # as the result type.
+  # @param ignore_warnings [Boolean] Whether to ignore warnings or not
   def resolve_with_support(ignore_warnings: false, **args)
     result = super(**args)
 
@@ -51,10 +94,12 @@ module FancyMutation
     }
   end
 
+  # A list of errors from the mutation. Push to this list from your resolve method.
   def errors
     @errors ||= []
   end
 
+  # A list of warnings from the mutation. Push to this list from your resolve method.
   def warnings
     @warnings ||= []
   end

--- a/app/graphql/concerns/fancy_mutation.rb
+++ b/app/graphql/concerns/fancy_mutation.rb
@@ -19,7 +19,11 @@ module FancyMutation
       union_name = "#{graphql_name}ErrorsUnion"
       union = Class.new(Types::Union::Base) do
         graphql_name union_name
-        possible_types types
+        possible_types(*types)
+
+        def self.resolve_type(object, _context)
+          object.key?(:__type) ? object[:__type] : super
+        end
       end
       field :errors, [union], null: true
     end

--- a/app/graphql/concerns/fancy_mutation.rb
+++ b/app/graphql/concerns/fancy_mutation.rb
@@ -1,0 +1,52 @@
+module FancyMutation
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def result(type, **kwargs)
+      field :result, type, **kwargs
+    end
+
+    def input(&block)
+      input_name = "#{graphql_name}Input"
+      input = Class.new(Types::Input::Base) do
+        graphql_name input_name
+        instance_eval(&block)
+      end
+      argument :input, input, required: true
+    end
+
+    def errors(*types)
+      union_name = "#{graphql_name}ErrorsUnion"
+      union = Class.new(Types::Union::Base) do
+        graphql_name union_name
+        possible_types types
+      end
+      field :errors, [union], null: true
+    end
+
+    def warnings(*types)
+      union_name = "#{graphql_name}WarningsUnion"
+      union = Class.new(Types::Union::Base) do
+        graphql_name union_name
+        possible_types types.flatten
+      end
+      field :errors, [union], null: true
+    end
+  end
+
+  def resolve_with_support(ignore_warnings: false, **args)
+    result = super(**args)
+
+    raise ActiveRecord::Rollback unless warnings.blank? || ignore_warnings
+
+    { result: result, warnings: warnings, errors: errors }
+  end
+
+  def errors
+    @errors ||= []
+  end
+
+  def warnings
+    @warnings ||= []
+  end
+end

--- a/app/graphql/mutations/account.rb
+++ b/app/graphql/mutations/account.rb
@@ -2,6 +2,4 @@ class Mutations::Account < Mutations::Namespace
   field :send_password_reset,
     mutation: Mutations::Account::SendPasswordReset,
     description: 'Send a password reset email'
-
-  field :create, mutation: Mutations::Account::Create
 end

--- a/app/graphql/mutations/account.rb
+++ b/app/graphql/mutations/account.rb
@@ -2,4 +2,6 @@ class Mutations::Account < Mutations::Namespace
   field :send_password_reset,
     mutation: Mutations::Account::SendPasswordReset,
     description: 'Send a password reset email'
+
+  field :create, mutation: Mutations::Account::Create
 end

--- a/app/graphql/mutations/account/create.rb
+++ b/app/graphql/mutations/account/create.rb
@@ -1,0 +1,35 @@
+class Mutations::Account::Create < Mutations::Base
+  include PublicMutation
+  include RateLimitedMutation
+  include FancyMutation
+
+  description 'Create a new Kitsu account'
+
+  rate_limit do
+    limit 20, per: 1.hour
+    limit 20, per: 2.days
+  end
+
+  input do
+    argument :name, String,
+      required: true,
+      description: 'The name of the user'
+
+    argument :email, String,
+      required: true,
+      description: 'The email address to reset the password for'
+
+    argument :password, String,
+      required: true,
+      description: 'The password for the user'
+
+    argument :external_identity, Types::Input::Account::ExternalIdentity,
+      required: false,
+      description: 'An external identity to associate with the account on creation'
+  end
+  result Types::Account
+
+  def resolve(input:)
+    AccountMutator.create(**input)
+  end
+end

--- a/app/graphql/mutations/account/create.rb
+++ b/app/graphql/mutations/account/create.rb
@@ -28,8 +28,15 @@ class Mutations::Account::Create < Mutations::Base
       description: 'An external identity to associate with the account on creation'
   end
   result Types::Account
+  errors Types::Errors::Validation
 
   def resolve(input:)
     AccountMutator.create(**input)
+  rescue ActiveRecord::RecordInvalid => e
+    validation_errors = Types::Errors::Validation.for_record(e.record, transform_path: ->(path) {
+      path = path.map { |p| p == 'password_digest' ? 'password' : p }
+      ['input', *path]
+    })
+    errors.push(*validation_errors)
   end
 end

--- a/app/graphql/mutations/base.rb
+++ b/app/graphql/mutations/base.rb
@@ -1,16 +1,6 @@
 class Mutations::Base < GraphQL::Schema::Mutation
   include BehindFeatureFlag
 
-  def authorized?(record, action)
-    return true if Pundit.policy!(context[:token], record).public_send(action)
-
-    [false, {
-      errors: [
-        { message: message, code: 'NotAuthorized' }
-      ]
-    }]
-  end
-
   def current_user
     context[:user]
   end

--- a/app/graphql/mutations/base.rb
+++ b/app/graphql/mutations/base.rb
@@ -18,6 +18,6 @@ class Mutations::Base < GraphQL::Schema::Mutation
   def self.default_graphql_name
     # Mutations::Anime::Create -> AnimeCreate
     # Mutations::LibraryEntry::UpdateStatusById -> LibraryEntryUpdateStatusById
-    name.split('::')[1..-1].join
+    name.split('::')[1..].join
   end
 end

--- a/app/graphql/mutations/base.rb
+++ b/app/graphql/mutations/base.rb
@@ -12,7 +12,11 @@ class Mutations::Base < GraphQL::Schema::Mutation
   end
 
   def current_user
-    User.current.presence || context[:user]
+    context[:user]
+  end
+
+  def current_token
+    context[:token]
   end
 
   def self.default_graphql_name

--- a/app/graphql/mutations/library_entry/create.rb
+++ b/app/graphql/mutations/library_entry/create.rb
@@ -15,7 +15,13 @@ class Mutations::LibraryEntry::Create < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :create?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).create?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/delete.rb
+++ b/app/graphql/mutations/library_entry/delete.rb
@@ -15,7 +15,13 @@ class Mutations::LibraryEntry::Delete < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :destroy?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).destroy?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/update.rb
+++ b/app/graphql/mutations/library_entry/update.rb
@@ -22,7 +22,13 @@ class Mutations::LibraryEntry::Update < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :update?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).update?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/update_progress_by_id.rb
+++ b/app/graphql/mutations/library_entry/update_progress_by_id.rb
@@ -17,7 +17,13 @@ class Mutations::LibraryEntry::UpdateProgressById < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :update?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).update?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/update_progress_by_media.rb
+++ b/app/graphql/mutations/library_entry/update_progress_by_media.rb
@@ -21,7 +21,13 @@ class Mutations::LibraryEntry::UpdateProgressByMedia < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :update?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).update?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/update_rating_by_id.rb
+++ b/app/graphql/mutations/library_entry/update_rating_by_id.rb
@@ -17,7 +17,13 @@ class Mutations::LibraryEntry::UpdateRatingById < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :update?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).update?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/update_rating_by_media.rb
+++ b/app/graphql/mutations/library_entry/update_rating_by_media.rb
@@ -21,7 +21,13 @@ class Mutations::LibraryEntry::UpdateRatingByMedia < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :update?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).update?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/update_status_by_id.rb
+++ b/app/graphql/mutations/library_entry/update_status_by_id.rb
@@ -17,7 +17,13 @@ class Mutations::LibraryEntry::UpdateStatusById < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :update?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).update?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/mutations/library_entry/update_status_by_media.rb
+++ b/app/graphql/mutations/library_entry/update_status_by_media.rb
@@ -21,7 +21,13 @@ class Mutations::LibraryEntry::UpdateStatusByMedia < Mutations::Base
   end
 
   def authorized?(library_entry:)
-    super(library_entry, :update?)
+    return true if LibraryEntryPolicy.new(context[:token], library_entry).update?
+
+    [false, {
+      errors: [
+        { message: 'Not Authorized', code: 'NotAuthorized' }
+      ]
+    }]
   end
 
   def resolve(library_entry:)

--- a/app/graphql/types/enum/external_identity_provider.rb
+++ b/app/graphql/types/enum/external_identity_provider.rb
@@ -1,0 +1,3 @@
+class Types::Enum::ExternalIdentityProvider < Types::Enum::Base
+  value 'FACEBOOK', 'Facebook identity', value: :facebook
+end

--- a/app/graphql/types/errors/base.rb
+++ b/app/graphql/types/errors/base.rb
@@ -1,0 +1,11 @@
+class Types::Errors::Base < Types::BaseObject
+  implements Types::Interface::Error
+
+  def self.build(**object)
+    { __type: self, **object }
+  end
+
+  def self.default_graphql_name
+    "#{name.split('::')[-1]}Error"
+  end
+end

--- a/app/graphql/types/errors/generic.rb
+++ b/app/graphql/types/errors/generic.rb
@@ -1,3 +1,1 @@
-class Types::Errors::Generic < Types::BaseObject
-  implements Types::Interface::Error
-end
+class Types::Errors::Generic < Types::Errors::Base; end

--- a/app/graphql/types/errors/not_authenticated.rb
+++ b/app/graphql/types/errors/not_authenticated.rb
@@ -1,0 +1,1 @@
+class Types::Errors::NotAuthenticated < Types::Errors::Base; end

--- a/app/graphql/types/errors/not_authorized.rb
+++ b/app/graphql/types/errors/not_authorized.rb
@@ -1,0 +1,3 @@
+class Types::Errors::NotAuthorized < Types::Errors::Base
+  field :action, String, null: true
+end

--- a/app/graphql/types/errors/validation.rb
+++ b/app/graphql/types/errors/validation.rb
@@ -1,0 +1,11 @@
+class Types::Errors::Validation < Types::Errors::Base
+  def self.for_record(record, transform_path:)
+    record.errors.flat_map do |key, message|
+      path = transform_path.nil? ? [key.to_s] : transform_path.call([key.to_s])
+      build({
+        path: path,
+        message: message
+      })
+    end
+  end
+end

--- a/app/graphql/types/errors/warnings_present.rb
+++ b/app/graphql/types/errors/warnings_present.rb
@@ -1,0 +1,10 @@
+class Types::Errors::WarningsPresent < Types::Errors::Base
+  description <<~DESCRIPTION.squish
+    Returned when a warning is present in the response from a mutation but the input did not specify
+    ignore_warnings: true
+  DESCRIPTION
+
+  def message
+    I18n.t('graphql.errors.warnings_present')
+  end
+end

--- a/app/graphql/types/input/account/external_identity.rb
+++ b/app/graphql/types/input/account/external_identity.rb
@@ -1,0 +1,4 @@
+class Types::Input::Account::ExternalIdentity < Types::Input::Base
+  argument :provider, Types::Enum::ExternalIdentityProvider, required: true
+  argument :id, String, required: true
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,4 +1,12 @@
 class Types::MutationType < Types::BaseObject
+  def self.fancy_mutation(
+    klass,
+    name: klass.name.split('::')[1..].join.camelize(:lower)
+  )
+    field name, mutation: klass
+  end
+
+  fancy_mutation Mutations::Account::Create
   field :pro, Mutations::Pro, null: false
   field :account, Mutations::Account, null: false
   field :anime, Mutations::Anime, null: false

--- a/app/mutators/account_mutator.rb
+++ b/app/mutators/account_mutator.rb
@@ -1,0 +1,27 @@
+class AccountMutator
+  # Create an account for a user
+  #
+  # @param [String] email The email address of the user to register
+  # @param [String] password The password to set for the user
+  # @param [String] name The name of the user
+  # @param [Hash,nil] external_identity An external account to associate with the user
+  # @option external_identity [:facebook] :provider The provider of the external account
+  # @option external_identity [String] :id The ID of the user's account on the external provider
+  # @return [User] The user that was created
+  # @raises [ActiveRecord::ActiveRecordError] If the email is already registered
+  # @raises [ArgumentError] If the provider is unknown
+  def self.create(email:, password:, name:, external_identity: nil)
+    if external_identity && external_identity[:provider] != :facebook
+      raise ArgumentError, 'Identity provider is not supported'
+    end
+
+    # TODO: Send the email in-band and see if it hard bounces before creation
+
+    User.create!(
+      email: email,
+      password: password,
+      name: name,
+      facebook_id: external_identity && external_identity[:id]
+    )
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,3 +59,6 @@ en:
       subject: "Welcome to Kitsu %{tier}"
     cancellation_email:
       subject: "Your Kitsu %{tier} subscription has been cancelled"
+  graphql:
+    errors:
+      warnings_present: "A warning was present and ignore_warnings was not set to true"

--- a/spec/graphql/concerns/fancy_mutation_spec.rb
+++ b/spec/graphql/concerns/fancy_mutation_spec.rb
@@ -1,0 +1,461 @@
+require 'rails_helper'
+
+RSpec.describe FancyMutation do
+  it 'does not expose the private class methods' do
+    mutation = Class.new { include FancyMutation }.new
+
+    expect(mutation).not_to respond_to(:errors_union)
+    expect(mutation).not_to respond_to(:warnings_union)
+    expect(mutation).not_to respond_to(:input_type)
+  end
+
+  describe '#ready?' do
+    context 'with no errors added' do
+      it 'passes out the return value' do
+        mutation = Class.new do
+          include FancyMutation
+
+          def ready?(*)
+            [true, 'test']
+          end
+        end
+
+        result = mutation.new.ready?
+        expect(result).to eq([true, 'test'])
+      end
+    end
+
+    context 'with errors added' do
+      it 'returns the errors in an object' do
+        mutation = Class.new do
+          include FancyMutation
+
+          def ready?(*)
+            errors << 'test'
+          end
+        end
+
+        result = mutation.new.ready?
+        expect(result).to eq([false, { errors: ['test'] }])
+      end
+    end
+  end
+
+  describe '#authorized?' do
+    context 'with no errors added' do
+      it 'passes out the return value' do
+        mutation = Class.new do
+          include FancyMutation
+
+          def authorized?(*)
+            [true, 'test']
+          end
+        end
+
+        result = mutation.new.authorized?
+        expect(result).to eq([true, 'test'])
+      end
+    end
+
+    context 'with errors added' do
+      it 'returns the errors in an object' do
+        mutation = Class.new do
+          include FancyMutation
+
+          def authorized?(*)
+            errors << 'test'
+          end
+        end
+
+        result = mutation.new.authorized?
+        expect(result).to eq([false, { errors: ['test'] }])
+      end
+    end
+  end
+
+  describe '.result' do
+    it 'creates a field named "result" with the provided type' do
+      result_type = Class.new(Types::BaseObject) do
+        graphql_name 'TestResult'
+      end
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        result result_type
+      end
+
+      expect(mutation.fields['result'].type.graphql_name).to eq('TestResult')
+    end
+
+    it 'passes through any arguments to the field' do
+      result_type = Class.new(Types::BaseObject) do
+        graphql_name 'TestResult'
+      end
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        result result_type, description: '__testing__'
+      end
+
+      expect(mutation.fields['result'].description).to eq('__testing__')
+    end
+  end
+
+  describe '.input' do
+    it 'creates a field named "input" with a generated, required input type' do
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        input {} # rubocop:disable Lint/EmptyBlock
+      end
+
+      expect(mutation.arguments['input'].type).to be_a(GraphQL::Schema::NonNull)
+      expect(mutation.arguments['input'].type.of_type.graphql_name).to eq('TestMutationInput')
+    end
+
+    it 'allows setting arguments on the input type' do
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        input do
+          argument :test, String, required: true
+        end
+      end
+      input_arguments = mutation.arguments['input'].type.of_type.arguments
+
+      expect(input_arguments).to have_key('test')
+    end
+
+    it 'can be called multiple times to add arguments to the input type' do
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        input do
+          argument :test_a, String, required: true
+        end
+
+        input do
+          argument :test_b, String, required: true
+        end
+      end
+      input_arguments = mutation.arguments['input'].type.of_type.arguments
+
+      expect(input_arguments).to have_key('testA')
+      expect(input_arguments).to have_key('testB')
+    end
+  end
+
+  describe '.errors' do
+    it 'adds an errors field of type [union!]' do
+      error_type = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        errors error_type
+      end
+
+      expect(mutation.fields).to have_key('errors')
+      errors_union = mutation.fields['errors'].type.of_type.of_type
+      expect(errors_union.graphql_name).to eq('TestMutationErrorsUnion')
+    end
+
+    it 'adds the provided types to the union type' do
+      error_type = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        errors error_type
+      end
+      error_types = mutation.fields['errors'].type.of_type.of_type.possible_types
+
+      expect(error_types).to include(error_type)
+    end
+
+    it 'can be called multiple times to add to the union' do
+      error_type_a = Class.new(Types::BaseObject)
+      error_type_b = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        errors error_type_a
+        errors error_type_b
+      end
+      error_types = mutation.fields['errors'].type.of_type.of_type.possible_types
+
+      expect(error_types).to include(error_type_a)
+      expect(error_types).to include(error_type_b)
+    end
+
+    it 'resolves the union type based on the __type key' do
+      error_type = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        errors error_type
+      end
+      error_union = mutation.fields['errors'].type.of_type.of_type
+      resolved_type = error_union.resolve_type({ __type: error_type }, {})
+
+      expect(resolved_type).to eq(error_type)
+    end
+  end
+
+  describe '.warnings' do
+    it 'adds a warnings field of type [union!]' do
+      warning_type = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        warnings warning_type
+      end
+
+      expect(mutation.fields).to have_key('warnings')
+      warnings_union = mutation.fields['warnings'].type.of_type.of_type
+      expect(warnings_union.graphql_name).to eq('TestMutationWarningsUnion')
+    end
+
+    it 'adds an ignore_warnings argument to the input type' do
+      warning_type = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        warnings warning_type
+      end
+      input_type = mutation.arguments['input'].type.of_type
+
+      expect(input_type.arguments).to have_key('ignoreWarnings')
+      expect(input_type.arguments['ignoreWarnings'].type).to eq(GraphQL::Types::Boolean)
+    end
+
+    it 'adds the provided types to the union type' do
+      warning_type = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        warnings warning_type
+      end
+      warning_types = mutation.fields['warnings'].type.of_type.of_type.possible_types
+
+      expect(warning_types).to include(warning_type)
+    end
+
+    it 'can be called multiple times to add to the union' do
+      warning_type_a = Class.new(Types::BaseObject)
+      warning_type_b = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        warnings warning_type_a
+        warnings warning_type_b
+      end
+      warning_types = mutation.fields['warnings'].type.of_type.of_type.possible_types
+
+      expect(warning_types).to include(warning_type_a)
+      expect(warning_types).to include(warning_type_b)
+    end
+
+    it 'resolves the union type based on the __type key' do
+      warning_type = Class.new(Types::BaseObject)
+      mutation = Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        warnings warning_type
+      end
+      warning_union = mutation.fields['warnings'].type.of_type.of_type
+      resolved_type = warning_union.resolve_type({ __type: warning_type }, {})
+
+      expect(resolved_type).to eq(warning_type)
+    end
+  end
+
+  describe '#resolve_with_support' do
+    let(:test_warning) do
+      Class.new(Types::BaseObject) do
+        graphql_name 'TestWarning'
+      end
+    end
+    let(:mutation) do
+      test_warning = self.test_warning
+      Class.new(Mutations::Base) do
+        graphql_name 'TestMutation'
+        include FancyMutation
+
+        warnings test_warning
+        errors Types::Errors::NotAuthenticated
+        result String
+      end
+    end
+    let(:mutation_type) do
+      mutation = self.mutation
+      Class.new(Types::BaseObject) do
+        graphql_name 'TestMutationSchema'
+        field :test, mutation: mutation
+      end
+    end
+    let(:schema) do
+      mutation_type = self.mutation_type
+      Class.new(GraphQL::Schema) do
+        mutation mutation_type
+      end
+    end
+
+    context 'when the result is the same as the errors list' do
+      it 'returns the result as nil' do
+        mutation.define_method(:resolve) do |*_|
+          errors << Types::Errors::NotAuthenticated.build
+        end
+
+        response = schema.execute(<<~GRAPHQL).dig('data', 'test')
+          mutation {
+            test(input: {}) {
+              result
+            }
+          }
+        GRAPHQL
+
+        expect(response['result']).to be_nil
+      end
+    end
+
+    context 'when warnings are present' do
+      context 'and ignore_warnings is false or not present' do
+        it 'rolls back the transaction' do
+          test_warning = self.test_warning
+          mutation.define_method(:resolve) do |*_|
+            warnings << { __type: test_warning }
+            FactoryBot.create(:anime)
+          end
+
+          expect {
+            schema.execute(<<~GRAPHQL)
+              mutation {
+                test(input: {}) { }
+              }
+            GRAPHQL
+          }.not_to change(Anime, :count)
+        end
+
+        it 'returns the warnings as a field' do
+          test_warning = self.test_warning
+          mutation.define_method(:resolve) do |*_|
+            warnings << { __type: test_warning }
+          end
+
+          response = schema.execute(<<~GRAPHQL).dig('data', 'test')
+            mutation {
+              test(input: {}) {
+                warnings {
+                  __typename
+                }
+              }
+            }
+          GRAPHQL
+
+          expect(response['warnings']).to include({ '__typename' => 'TestWarning' })
+        end
+
+        it 'adds a WarningsPresent error' do
+          test_warning = self.test_warning
+          mutation.define_method(:resolve) do |*_|
+            warnings << { __type: test_warning }
+          end
+
+          response = schema.execute(<<~GRAPHQL).dig('data', 'test')
+            mutation {
+              test(input: {}) {
+                errors {
+                  __typename
+                }
+              }
+            }
+          GRAPHQL
+
+          expect(response['errors']).to include({ '__typename' => 'WarningsPresentError' })
+        end
+
+        it 'makes the result nil' do
+          test_warning = self.test_warning
+          mutation.define_method(:resolve) do |*_|
+            warnings << { __type: test_warning }
+            'test'
+          end
+
+          response = schema.execute(<<~GRAPHQL).dig('data', 'test')
+            mutation {
+              test(input: {}) {
+                result
+              }
+            }
+          GRAPHQL
+
+          expect(response['result']).to be_nil
+        end
+      end
+    end
+  end
+
+  describe '#authenticate!' do
+    it 'adds a NotAuthenticated error if the user is not authenticated' do
+      mutation = Struct.new(:current_user) do
+        include FancyMutation
+      end
+
+      instance = mutation.new(nil)
+      instance.authenticate!
+      expect(instance.errors).to include(Types::Errors::NotAuthenticated.build)
+    end
+
+    it 'returns true' do
+      mutation = Struct.new(:current_user) do
+        include FancyMutation
+      end
+
+      result = mutation.new(nil).authenticate!
+      expect(result).to eq(true)
+    end
+  end
+
+  describe '#authorize!' do
+    context 'without an explicit policy' do
+      it "checks the action on the object's implicit policy" do
+        policy = instance_spy('AnimePolicy')
+        policy_class = class_double('AnimePolicyClass', new: policy)
+        stub_const('AnimePolicy', policy_class)
+        mutation = Struct.new(:current_token) do
+          include FancyMutation
+        end
+
+        mutation.new(nil).authorize!(Anime.new, :create?)
+        expect(policy).to have_received(:create?)
+      end
+    end
+
+    context 'with an explicit policy' do
+      it 'adds a NotAuthorized error if the policy rejects it' do
+        policy = instance_double('AnimePolicy', create?: false)
+        policy_class = class_double('AnimePolicyClass', new: policy)
+        mutation = Struct.new(:current_token) do
+          include FancyMutation
+        end
+
+        instance = mutation.new(nil)
+        instance.authorize!(Anime.new, :create?, policy: policy_class)
+        expect(instance.errors).to include(include(Types::Errors::NotAuthorized.build))
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What
Despite the small diff, there's actually three new things in this single PR. It's a work-in-progress, but I want to demonstrate the new concepts early and get feedback.

## FancyMutation
- A standardized way of structuring mutations
- A set of class methods to make that structure easy to adhere to
- **TODO:** provide an easy way to bind GraphQL error types to Ruby error types

## Mutators
- Plain-ass ruby classes
- Holds business logic like a controller
- Leaves any serialization/deserialization to the GraphQL layer
  - In future, I might make a shorthand for hooking this up to a FancyMutation with no de/serialization required

## `Account.create` mutation
- Allows creating an account
- Rate limited to 20 attempts in an hour or 20 attempts in 2 days.
  - **TODO:** limit *successful* mutations, so we can drop the limit significantly
- **TODO:** set up error handling

# Why

## FancyMutation
- Encourage consistency and adherence to best practices
  - Errors in GraphQL via an interface+union approach
  - Inputs as an object instead of separate parameters
- Make it easy to do input objects instead of putting your parameters in a separate file in a completely weird separate folder

## Mutators
- My previous Actions system was frankly just way overcomplicated and stupid
- I wanted something which could encapsulate and document business logic separate from the API layer
- Allow testing shit or performing actions from the console without parsing GraphQL
- Fuck it, class methods will do the trick

## `Account.create` mutation
- Demonstrate FancyMutation and Mutators
- Allow creating an account from V4