### PR TITLE
Fix broken link to user profile

### DIFF
--- a/app/graphql/types/profile.rb
+++ b/app/graphql/types/profile.rb
@@ -14,7 +14,7 @@ class Types::Profile < Types::BaseObject
     description: 'A fully qualified URL to the profile'
 
   def url
-    "https://kitsu/users/#{object.slug || object.id}"
+    "https://kitsu.io/users/#{object.slug || object.id}"
   end
 
   field :name, String,


### PR DESCRIPTION
This should fix the broken link to a user profile when fetching it from the Graphql API

<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What
Fixes a bug in the GraphQL API
When trying to fetch a user url
E.g
```
query userByID  {
    findProfileById (id: 5554) {
	url
   }
}
```
it returns
```
{
  "data": {
    "findProfileById": {
      "url": "https://kitsu/users/Nuck"
    }
  }
}
```
The url is missing the .io
<!-- Please summarize your changes.  This includes:

- What bugs did you fix?
- What features did you add?
- Did you add any dependencies? -->

# Why

<!-- Explain why you implemented this how you did.  This includes:

- What decisions did you make while building this?
- What are some alternatives you considered?
- What are some downsides of the approach you chose?
- Did you discuss those decisions with anyone else?  What were their thoughts? -->

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
