### PR TITLE
Add `ProfileLinkSite` to `SiteLink`

### DIFF
--- a/app/graphql/types/profile_link_site.rb
+++ b/app/graphql/types/profile_link_site.rb
@@ -1,0 +1,15 @@
+class Types::ProfileLinkSite < Types::BaseObject
+  implements Types::Interface::WithTimestamps
+  
+  field :id, ID, null: false
+
+  field :name, String,
+    null: false,
+    description: 'Name of the external profile website.'
+
+  field :validate_find, String,
+    description: 'Regex pattern used to validate the profile link.'
+
+  field :validate_replace, String,
+    description: 'Pattern to be replaced after validation.'
+end

--- a/app/graphql/types/profile_link_site.rb
+++ b/app/graphql/types/profile_link_site.rb
@@ -10,8 +10,10 @@ class Types::ProfileLinkSite < Types::BaseObject
     description: 'Name of the external profile website.'
 
   field :validate_find, String,
+    null: false,
     description: 'Regex pattern used to validate the profile link.'
 
   field :validate_replace, String,
+    null: false,
     description: 'Pattern to be replaced after validation.'
 end

--- a/app/graphql/types/profile_link_site.rb
+++ b/app/graphql/types/profile_link_site.rb
@@ -1,6 +1,6 @@
 class Types::ProfileLinkSite < Types::BaseObject
   implements Types::Interface::WithTimestamps
-  
+
   field :id, ID, null: false
 
   field :name, String,

--- a/app/graphql/types/profile_link_site.rb
+++ b/app/graphql/types/profile_link_site.rb
@@ -1,6 +1,8 @@
 class Types::ProfileLinkSite < Types::BaseObject
   implements Types::Interface::WithTimestamps
 
+  description 'An external site that can be linked to a user.'
+
   field :id, ID, null: false
 
   field :name, String,

--- a/app/graphql/types/site_link.rb
+++ b/app/graphql/types/site_link.rb
@@ -5,6 +5,14 @@ class Types::SiteLink < Types::BaseObject
 
   field :id, ID, null: false
 
+  field :site, Types::ProfileLinkSite,
+    null: false,
+    description: 'The actual linked website.'
+
+  def site
+    Loaders::RecordLoader.for(::ProfileLinkSite, token: context[:token]).load(object.profile_link_site_id)
+  end
+
   field :url, String,
     null: false,
     description: 'A fully qualified URL of the user profile on an external site.'

--- a/app/graphql/types/site_link.rb
+++ b/app/graphql/types/site_link.rb
@@ -10,7 +10,10 @@ class Types::SiteLink < Types::BaseObject
     description: 'The actual linked website.'
 
   def site
-    Loaders::RecordLoader.for(::ProfileLinkSite, token: context[:token]).load(object.profile_link_site_id)
+    Loaders::RecordLoader.for(
+      ::ProfileLinkSite,
+      token: context[:token]
+    ).load(object.profile_link_site_id)
   end
 
   field :url, String,


### PR DESCRIPTION
This PR fixes issue #1259

<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What

This PR resolve #1259:
Unlike the JSON:API, in the GraphQL Api it wasn't possible to get ProfileLinkSite

In the JSON:API it could be included by doing
`https://kitsu.io/api/edge/users/1/profile-links?include=profileLinkSite`

# Why

<!-- Explain why you implemented this how you did.  This includes:

- What decisions did you make while building this?
- What are some alternatives you considered?
- What are some downsides of the approach you chose?
- Did you discuss those decisions with anyone else?  What were their thoughts? -->

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [ ] Tests have been added to cover the new code
