### PR TITLE
Fix library entry media field

### DIFF
--- a/app/graphql/types/library_entry.rb
+++ b/app/graphql/types/library_entry.rb
@@ -14,7 +14,10 @@ class Types::LibraryEntry < Types::BaseObject
     description: 'The media related to this library entry.'
 
   def media
-    Loaders::RecordLoader.for(object.media_type.safe_constantize).load(object.media_id)
+    Loaders::RecordLoader.for(
+      object.media_type.safe_constantize,
+      token: context[:token]
+    ).load(object.media_id)
   end
 
   field :last_unit, Types::Interface::Unit,


### PR DESCRIPTION
It was not giving back the media if it was NSFW and the sfw filter was turned off

<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What
Fix media not being given back in library entry query if it was NSFW.
<!-- Please summarize your changes.  This includes:

- What bugs did you fix?
- What features did you add?
- Did you add any dependencies? -->

# Why
It throws an error whenever you try to query the entry

STEPS:
* Add a R18 media in your library on kitsu website as COMPLETED
* Go on [kitsu playground](https://kitsu.io/api/playground)
* Write the following query 
```graphql
query session{
  currentAccount {
    profile{
      library{
        completed(mediaType: ANIME, first: 100) {
          nodes {
            nsfw
            media{
              id
            }
          }          
        }
      }
    }
  }
}
```
and add the Authorization Header
* Query

It should return this error
![image](https://user-images.githubusercontent.com/61943525/208450093-de7d3de8-e90f-4bb6-9638-797af198194c.png)

<!-- Explain why you implemented this how you did.  This includes:

- What decisions did you make while building this?
- What are some alternatives you considered?
- What are some downsides of the approach you chose?
- Did you discuss those decisions with anyone else?  What were their thoughts? -->

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [ ] Tests have been added to cover the new code
