### PR TITLE
Allow raising graphql error types to halt execution in a FancyMutation

### DIFF
--- a/app/graphql/types/errors/base.rb
+++ b/app/graphql/types/errors/base.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
 class Types::Errors::Base < Types::BaseObject
   implements Types::Interface::Error
+
+  def self.exception(object = {})
+    FancyMutation::ErrorWrapper.new(build(**object))
+  end
 
   def self.build(**object)
     { __type: self, **object }


### PR DESCRIPTION
# What

- Allow halting execution of GraphQL mutations early while still returning a well-formed error response
- Does so by wrapping the error hash in a raiseable exception type
- This is implemented as `.exception` on the Base error type, which `raise` calls to wrap it

## Example

```ruby
def resolve(id:, name:)
  record = Thing.find_by(id:)
  raise Types::Errors::NotFound unless record

  record.update!(name:)
end
```

# Why

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
