### PR TITLE
Make Height and Width show correctly for the original file

### DIFF
--- a/app/graphql/types/image.rb
+++ b/app/graphql/types/image.rb
@@ -8,8 +8,8 @@ class Types::Image < Types::BaseObject
     {
       name: 'original',
       url: object.file.url,
-      width: object.file.url,
-      height: object.file.url
+      width: object.file.width,
+      height: object.file.height
     }
   end
 


### PR DESCRIPTION
<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What
This makes height and width show correctly when loading an image original field
<!-- Please summarize your changes.  This includes:

- What bugs did you fix?
- What features did you add?
- Did you add any dependencies? -->

# Why
Before this it always returned 0 for the height and width of an Image. 
![image](https://github.com/hummingbird-me/kitsu-server/assets/61943525/6e77fb34-de97-498f-9c42-19103d56776b)

<!-- Explain why you implemented this how you did.  This includes:

- What decisions did you make while building this?
- What are some alternatives you considered?
- What are some downsides of the approach you chose?
- Did you discuss those decisions with anyone else?  What were their thoughts? -->

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
