### PR TITLE
GraphQL: Return all volume table data. Add description field

### DIFF
--- a/app/graphql/types/volume.rb
+++ b/app/graphql/types/volume.rb
@@ -1,24 +1,8 @@
 class Types::Volume < Types::BaseObject
+  implements Types::Interface::Unit
   implements Types::Interface::WithTimestamps
 
   description 'A manga volume which can contain multiple chapters.'
-
-  field :id, ID, null: false
-
-  field :titles, Types::TitlesList,
-    null: false,
-    description: 'The titles for this chapter in various locales'
-
-  def titles
-    {
-      localized: object.titles,
-      canonical: object.canonical_title
-    }
-  end
-
-  field :number, Integer,
-    null: false,
-    description: 'The volume number.'
 
   field :published, GraphQL::Types::ISO8601Date,
     null: true,
@@ -32,6 +16,10 @@ class Types::Volume < Types::BaseObject
   field :isbn, [String],
     null: false,
     description: 'The isbn number of this volume.'
+
+  field :chapters_count, Integer,
+    null: true,
+    description: 'The number of chapters in this volume.'
 
   field :chapters, Types::Chapter.connection_type,
     null: true,

--- a/db/migrate/20231028222209_add_description_to_volumes.rb
+++ b/db/migrate/20231028222209_add_description_to_volumes.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToVolumes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :volumes, :description, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_04_041942) do
+ActiveRecord::Schema.define(version: 2023_10_28_222209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -1625,6 +1625,7 @@ ActiveRecord::Schema.define(version: 2022_12_04_041942) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "thumbnail_data"
+    t.jsonb "description", default: {}, null: false
   end
 
   create_table "votes", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
First PR here. Not sure on the checklist, should I mark as done those that aren't required or remove them?

# What

Adds a description field to `volumes` table.
Returns additional fields: thumbnail and (new) description

Closes #1446 

# Why

"Few, if any, chapters will have an official description and so relies on users to create them. Volumes on the other hand, will usually have descriptions created by the publisher.

Similarly to the above and it seems that the DB has an image field for volumes but isn't exposed via GQL."



# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
