### PR TITLE
Adds volume to manga type for GraphQL

### DIFF
--- a/app/graphql/loaders/volumes_loader.rb
+++ b/app/graphql/loaders/volumes_loader.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Loaders::VolumesLoader < GraphQL::FancyLoader
+  from Volume
+
+  sort :created_at
+  sort :updated_at
+  sort :number
+end

--- a/app/graphql/types/manga.rb
+++ b/app/graphql/types/manga.rb
@@ -20,6 +20,18 @@ class Types::Manga < Types::BaseObject
     null: true,
     description: 'The number of volumes in this manga.'
 
+  field :volumes, Types::Volume.connection_type, null: true do
+    description 'The volumes in the manga.'
+    argument :sort, Loaders::VolumesLoader.sort_argument, required: false
+  end
+
+  def volumes(sort: [{ on: :number, direction: :asc }])
+    Loaders::VolumesLoader.connection_for({
+      find_by: :manga_id,
+      sort:
+    }, object.id)
+  end
+
   field :chapters, Types::Chapter.connection_type, null: true do
     description 'The chapters in the manga.'
     argument :sort, Loaders::ChaptersLoader.sort_argument, required: false

--- a/app/policies/volume_policy.rb
+++ b/app/policies/volume_policy.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class VolumePolicy < ApplicationPolicy
+  administrated_by :database_mod
+end


### PR DESCRIPTION
# What
Adds `volumes` to `manga` in graphQL.

# Why

Closes #1445 
# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
