### PR TITLE
Allow typesense's requests in test environment

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -10,7 +10,8 @@ WebMock.disable_net_connect!(allow: [
   'localhost',
   'elasticsearch:9200',
   'minio:9000',
-  'oembed.com'
+  'oembed.com',
+  'typesense:8108'
 ])
 
 RSpec.shared_context 'MAL CDN' do


### PR DESCRIPTION
Allow typesense's requests under test environment so that webmock does not throw errors every time

<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What

<!-- Please summarize your changes.  This includes:

- What bugs did you fix?
- What features did you add?
- Did you add any dependencies? -->

# Why

<!-- Explain why you implemented this how you did.  This includes:

- What decisions did you make while building this?
- What are some alternatives you considered?
- What are some downsides of the approach you chose?
- Did you discuss those decisions with anyone else?  What were their thoughts? -->

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
