### PR TITLE
Updated profile link regex to match Discord's new username system. 

### DIFF
--- a/db/seeds/profile_link_sites.yml
+++ b/db/seeds/profile_link_sites.yml
@@ -56,7 +56,7 @@ raptr:
 discord:
   id: 12
   name: Discord
-  validate_find: '\A(.+#[0-9]+)\z'
+  validate_find: '\A(?!.*\.\.)[a-z0-9\_\.]{1,32}\z'
   validate_replace: '\1'
 tumblr:
   id: 13


### PR DESCRIPTION
# What

Changed Kitsu's profile link username regex for Discord. 

# Why

Because Discord changed it's username system. 

# Checklist

<!-- ALL PULL REQUESTS -->
- [x] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [x] All the tests pass
- [x] Tests have been added to cover the new code
