### PR TITLE
Wire User & Group JSONAPI search to Typesense (flag-gated)

### DIFF
--- a/app/indices/typesense_groups_index.rb
+++ b/app/indices/typesense_groups_index.rb
@@ -2,7 +2,6 @@
 
 class TypesenseGroupsIndex < TypesenseBaseIndex
   SAVE_FREQUENCIES = {
-    'id' => 1,
     'avatar_data' => 1,
     'name' => 1,
     'slug' => 1,
@@ -10,7 +9,9 @@ class TypesenseGroupsIndex < TypesenseBaseIndex
     'about' => 1,
     'locale' => 1,
     'privacy' => 1,
-    'is_nsfw' => 1,
+    'nsfw' => 1,
+    'category_id' => 1,
+    'featured' => 1,
     'members_count' => 0.1,
     'last_activity_at' => 0.5
   }.freeze
@@ -26,6 +27,8 @@ class TypesenseGroupsIndex < TypesenseBaseIndex
     field 'locale', type: 'string'
     field 'privacy', type: 'string'
     field 'is_nsfw', type: 'bool'
+    field 'featured', type: 'bool', facet: true
+    field 'category_id', type: 'int32', facet: true, optional: true
     field 'members_count', type: 'int32', facet: true
     # Last activity timestamp
     field 'last_activity_at', type: 'object'
@@ -55,9 +58,11 @@ class TypesenseGroupsIndex < TypesenseBaseIndex
         locale: group.locale || 'en-US',
         privacy: group.privacy,
         is_nsfw: group.nsfw?,
+        featured: group.featured,
+        category_id: group.category_id,
         members_count: group.members_count,
         last_activity_at: format_date(group.last_activity_at),
-        created_at: format_date(group.created_at)
+        created_at: group.created_at.to_i
       }.compact)
     end
   end

--- a/app/indices/typesense_users_index.rb
+++ b/app/indices/typesense_users_index.rb
@@ -7,6 +7,7 @@ class TypesenseUsersIndex < TypesenseBaseIndex
     'name' => 1,
     'past_names' => 1,
     'slug' => 1,
+    'deleted_at' => 1,
     'followers_count' => 0.025
   }.freeze
 
@@ -17,6 +18,7 @@ class TypesenseUsersIndex < TypesenseBaseIndex
     field 'name', type: 'string'
     field 'past_names', type: 'string[]'
     field 'slug', type: 'string', optional: true
+    field 'is_deleted', type: 'bool', facet: true
     field 'followers_count', type: 'int32', facet: true
   end
 
@@ -41,6 +43,7 @@ class TypesenseUsersIndex < TypesenseBaseIndex
           name: user.name,
           past_names: user.past_names || [],
           slug: user.slug,
+          is_deleted: user.deleted_at.present?,
           followers_count: user.followers_count,
           created_at: user.created_at.to_i
         }.compact)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -62,6 +62,11 @@ class Group < ApplicationRecord
     @kitsu ||= find_by(id: 1830)
   end
 
+  def self.typesense_index
+    TypesenseGroupsIndex
+  end
+  delegate :typesense_index, to: :class
+
   before_validation do
     self.nsfw = category_id == 9 if category_id_changed?
     true
@@ -71,5 +76,13 @@ class Group < ApplicationRecord
   # cares?)
   after_commit(on: :create) do
     feed.setup!
+  end
+
+  after_commit(on: %i[create update]) do
+    typesense_index.index_one(id) if typesense_index.should_sync?(saved_changes)
+  end
+
+  after_commit(on: :destroy) do
+    typesense_index.remove_one(id)
   end
 end

--- a/app/resources/group_resource.rb
+++ b/app/resources/group_resource.rb
@@ -57,6 +57,18 @@ class GroupResource < BaseResource
     member.permissions.create!(permission: :owner)
   end
 
+  def self._search_service
+    GroupSearchService if Flipper[:typesense_group_search].enabled?(User.current)
+  end
+
+  def self._paginator
+    if Flipper[:typesense_group_search].enabled?(User.current)
+      :universal
+    else
+      JSONAPI.configuration.default_paginator
+    end
+  end
+
   index GroupsIndex::Group
   query :query,
     mode: :query,

--- a/app/resources/user_resource.rb
+++ b/app/resources/user_resource.rb
@@ -101,6 +101,18 @@ class UserResource < BaseResource
     records.where(id: current_user&.id) || User.none
   }
 
+  def self._search_service
+    UserSearchService if Flipper[:typesense_user_search].enabled?(User.current)
+  end
+
+  def self._paginator
+    if Flipper[:typesense_user_search].enabled?(User.current)
+      :universal
+    else
+      JSONAPI.configuration.default_paginator
+    end
+  end
+
   index UsersIndex::User
   query :query,
     mode: :query,

--- a/app/services/group_search_service.rb
+++ b/app/services/group_search_service.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+class GroupSearchService < TypesenseSearchService
+  # Runs the search and returns the list of matching groups in order by their
+  # relevance to the query.
+  #
+  # @return [Array<Group>] the list of matching groups
+  def to_a
+    result_ids.map do |id|
+      result_groups[id.to_i]
+    end
+  end
+
+  def query_results
+    @query_results ||= query.include_fields(:id).load
+  end
+
+  # Exclude NSFW groups.  Mirrors GroupsIndex::Group.sfw so the PolicyScope can
+  # resolve identically against either backend.
+  def sfw
+    @sfw = true
+    self
+  end
+
+  # Limit to the groups visible to the given user.  Mirrors
+  # GroupsIndex::Group.visible_for: a user can see public (open/restricted)
+  # groups plus any closed group they belong to.
+  def visible_for(user)
+    @visible = true
+    @visible_user = user
+    self
+  end
+
+  private
+
+  def result_groups
+    @result_groups ||= Group.where(id: result_ids).index_by(&:id)
+  end
+
+  def result_ids
+    @result_ids ||= query_results.hits.map { |res| res.document['id'] }
+  end
+
+  def query
+    @query ||= begin
+      query = TypesenseGroupsIndex.search(
+        query: filters[:query]&.join(' ') || '',
+        query_by: {
+          'name' => 4,
+          'tagline' => 2,
+          'about' => 1
+        }
+      )
+      query = apply_sfw_filter_to(query)
+      query = apply_visibility_filter_to(query)
+      query = apply_auto_filter_for(query, :privacy)
+      query = apply_featured_filter_to(query)
+      query = apply_category_filter_to(query)
+      query = apply_order_to(query)
+      query = apply_page_to(query)
+      query = apply_per_to(query)
+      query
+    end
+  end
+
+  def apply_sfw_filter_to(scope)
+    return scope unless @sfw
+
+    scope.filter('is_nsfw:=false')
+  end
+
+  def apply_visibility_filter_to(scope)
+    return scope unless @visible
+
+    group_ids = visible_group_ids
+    if group_ids.present?
+      scope.filter("(id:=[#{group_ids.join(',')}] || privacy:=[open,restricted])")
+    else
+      scope.filter('privacy:=[open,restricted]')
+    end
+  end
+
+  def visible_group_ids
+    return [] unless @visible_user
+
+    GroupMember.joins(:group).merge(Group.closed).for_user(@visible_user).pluck(:group_id)
+  end
+
+  def apply_featured_filter_to(scope)
+    return scope unless filters.key?(:featured)
+
+    value = filters[:featured]
+    value = value.last if value.is_a?(Array)
+    scope.filter("featured:=#{value ? 'true' : 'false'}")
+  end
+
+  def apply_category_filter_to(scope)
+    return scope if filters[:category].blank?
+
+    category_ids = Array(filters[:category]).map { |category| category.try(:id) || category }
+    scope.filter("category_id:=[#{category_ids.join(',')}]")
+  end
+
+  def apply_order_to(scope)
+    return scope unless orders
+
+    improved_orders = orders.flat_map do |field, direction|
+      case field
+      when '_text_match'
+        [['_text_match(buckets: 6)', direction], ['members_count', direction]]
+      when 'last_activity_at'
+        [['last_activity_at.timestamp', direction]]
+      else
+        [[field, direction]]
+      end
+    end
+    scope.sort(improved_orders.to_h)
+  end
+end

--- a/app/services/user_search_service.rb
+++ b/app/services/user_search_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class UserSearchService < TypesenseSearchService
+  # Runs the search and returns the list of matching users in order by their
+  # relevance to the query.
+  #
+  # @return [Array<User>] the list of matching users
+  def to_a
+    result_ids.map do |id|
+      result_users[id.to_i]
+    end
+  end
+
+  def query_results
+    @query_results ||= query.include_fields(:id).load
+  end
+
+  # Exclude soft-deleted users.  Mirrors UsersIndex::User.active so the
+  # PolicyScope can resolve identically against either backend.
+  def active
+    @active = true
+    self
+  end
+
+  # Exclude the given user ids.  Mirrors UsersIndex::User.blocking.
+  def blocking(ids)
+    @blocking_ids = ids
+    self
+  end
+
+  private
+
+  def result_users
+    @result_users ||= User.where(id: result_ids).index_by(&:id)
+  end
+
+  def result_ids
+    @result_ids ||= query_results.hits.map { |res| res.document['id'] }
+  end
+
+  def query
+    @query ||= begin
+      query = TypesenseUsersIndex.search(
+        query: filters[:query]&.join(' ') || '',
+        query_by: {
+          'name' => 2,
+          'past_names' => 1
+        }
+      )
+      query = apply_active_filter_to(query)
+      query = apply_blocking_filter_to(query)
+      query = apply_order_to(query)
+      query = apply_page_to(query)
+      query = apply_per_to(query)
+      query
+    end
+  end
+
+  def apply_active_filter_to(scope)
+    return scope unless @active
+
+    scope.filter('is_deleted:=false')
+  end
+
+  def apply_blocking_filter_to(scope)
+    return scope if @blocking_ids.blank?
+
+    scope.filter("id:!=[#{@blocking_ids.join(',')}]")
+  end
+
+  def apply_order_to(scope)
+    return scope unless orders
+
+    # Replace _text_match with _text_match(buckets: 6),followers_count in the
+    # same direction.  This surfaces the more prominent accounts first, which is
+    # almost always what the searcher is looking for.
+    improved_orders = orders.flat_map do |field, direction|
+      if field == '_text_match'
+        [['_text_match(buckets: 6)', direction], ['followers_count', direction]]
+      else
+        [[field, direction]]
+      end
+    end
+    scope.sort(improved_orders.to_h)
+  end
+end


### PR DESCRIPTION
# What

Moves the **User** and **Group** JSONAPI filter-search off the Chewy/Elasticsearch read path and onto **Typesense**, behind per-model Flipper flags, matching the existing `AnimeResource`/`MangaResource` pattern. This is the next step in the Chewy → Typesense migration. Elasticsearch stays as the flag-off fallback, so the cutover is reversible and can roll out gradually.

- **New search services** (subclass `TypesenseSearchService`, mirror `AnimeSearchService`):
  - `UserSearchService` — searches `TypesenseUsersIndex` by `name`/`past_names`.
  - `GroupSearchService` — searches `TypesenseGroupsIndex` by `name`/`tagline`/`about`, and applies the `privacy`/`featured`/`category` filters that arrive alongside `query`.
- **Resource wiring** — flag-gated `_search_service` + `_paginator :universal`, exactly like `AnimeResource`, gated on `typesense_user_search` / `typesense_group_search`. The Chewy `index`/`query` declarations remain for the fallback.
- **Index changes for parity:**
  - `TypesenseUsersIndex`: added `is_deleted` (+ `deleted_at` to `SAVE_FREQUENCIES`) so `.active` can exclude soft-deleted users.
  - `TypesenseGroupsIndex`: added `featured`/`category_id` for the resource's filters; **fixed two latent bugs** — `SAVE_FREQUENCIES` keyed `is_nsfw` (never matched the `nsfw` column) and `created_at` was written as a hash against an `int32` field.
- **`Group` model**: added the `typesense_index` delegate + `after_commit` index/remove callbacks — Group previously only synced to Chewy, which is why the index bugs above never surfaced.

No new dependencies.

# Why

The JSONAPI search path (`SearchableResource#apply_scopes`) applies the resource's Pundit `Scope#resolve` to whatever the "query" object is. For the Chewy path that's a `Chewy::Query`; for the Typesense path it's the search service. So — following the `AnimeSearchService#sfw` precedent — each service implements the methods its scope calls:

- **User** → `.active` (`is_deleted:=false`) and `.blocking(ids)` (`id:!=[...]`)
- **Group** → `.sfw` (`is_nsfw:=false`) and `.visible_for(user)` (member-of closed groups OR open/restricted), reusing the existing `GroupPolicy::TypesensualScope` semantics.

Per-model Flipper flags (rather than a direct cutover) keep Elasticsearch as a per-request fallback and let the rollout happen gradually, consistent with `typesense_search` / `typesense_manga_search`.

**Deferred (out of scope):** Character, GroupMember, GroupTicket still read ES unconditionally — they have no Typesense index yet (GroupMember especially, being a denormalized member index). Drama is dead code and left alone.

**Reviewer notes / before merge:**
- The Users and Groups collections need a **reindex** for the new fields (`is_deleted`, `featured`, `category_id`) before the flags are enabled.
- Set `TYPESENSE_USERS_SEARCH_KEY` / `TYPESENSE_GROUPS_SEARCH_KEY` if not already present.
- RuboCop/specs were **not** run locally (the worktree's bundler env is missing a git-sourced gem); files were syntax-checked with `ruby -c` only.

# Checklist

- [ ] All files pass Rubocop
- [x] Any complex logic is commented
- [x] Any new systems have thorough documentation
- [x] Any user-facing changes are behind a feature flag (or: explain why they can't be)
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code