### PR TITLE
Fix GraphQL rating system docstrings

### DIFF
--- a/app/graphql/types/enum/rating_system.rb
+++ b/app/graphql/types/enum/rating_system.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Types::Enum::RatingSystem < Types::Enum::Base
-  SIMPLE = '1-20 displayed as 4 smileys - Awful (1), Meh (8), Good (14) and Great (20)'
-  REGULAR = '1-20 in increments of 2 displayed as 5 stars in 0.5 star increments'
-  ADVANCED = '1-20 in increments of 1 displayed as 1-10 in 0.5 increments'
+  SIMPLE = '2-20 displayed as 4 smileys - Awful (2), Meh (8), Good (14) and Great (20)'
+  REGULAR = '2-20 in increments of 2 displayed as 5 stars in 0.5 star increments'
+  ADVANCED = '2-20 in increments of 1 displayed as 1-10 in 0.5 increments'
 
   value 'SIMPLE', SIMPLE, value: 'simple'
   value 'REGULAR', REGULAR, value: 'regular'


### PR DESCRIPTION
<!-- Hi there, and thanks for sending a pull request to Kitsu!  The following is a guide to help you
write a great pull request description.

For "What" and "Why", just add your responses.
For "Checklist", just add an "x" to each one you believe to be done. -->

# What

Fixed the `RatingSystemEnum` member docstrings to reflect the real values being used by Kitsu.
<!-- Please summarize your changes.  This includes:

- What bugs did you fix?
- What features did you add?
- Did you add any dependencies? -->

# Why

I was working on mihonapp/mihon#3818 and thus checked the different score scales.

I'm also working on potentially migrating Mihon to the Kitsu GraphQL API and was confused by these docstrings, so I fixed them to reflect reality.

- "Simple" scoring goes 2-20 (step size 6)
  - 2 (Awful), 8 (Meh), 14 (Good), 20 (Great)
- "Regular" scoring goes 2-20 (step size 2)
  - 2 (0.5 stars), 4 (1.0 stars), 6 (1.5 stars), ..., 18 (4.5 stars), 20 (5.0 stars)
- "Advanced" scoring goes 2-20 (step size 1)
  - 2 (1.0), 3 (1.5), 4 (2.0), ..., 19 (9.5), 20 (10.0)

<!-- Explain why you implemented this how you did.  This includes:

- What decisions did you make while building this?
- What are some alternatives you considered?
- What are some downsides of the approach you chose?
- Did you discuss those decisions with anyone else?  What were their thoughts? -->

# Checklist

<!-- ALL PULL REQUESTS -->
- [ ] All files pass Rubocop
- [ ] Any complex logic is commented
- [ ] Any new systems have thorough documentation
- [ ] Any user-facing changes are behind a feature flag (or: explain why they can't be)
<!-- FINISHED (NON-DRAFT) PULL REQUESTS -->
- [ ] All the tests pass
- [ ] Tests have been added to cover the new code
